### PR TITLE
Refactor: Implement `ISemanticEventWriter` for semantic event writers

### DIFF
--- a/src/Core/Events/Semantic/SemanticEventWriter.cs
+++ b/src/Core/Events/Semantic/SemanticEventWriter.cs
@@ -4,6 +4,17 @@ using System.Runtime.CompilerServices;
 namespace ChangeTrace.Core.Events.Semantic;
 
 /// <summary>
+/// Non-generic contract used to clear semantic event writers after a frame flush.
+/// </summary>
+public interface ISemanticEventWriter
+{
+    /// <summary>
+    /// Clears all written events without releasing the underlying buffer.
+    /// </summary>
+    void Clear();
+}
+
+/// <summary>
 /// Writer for semantic events of type <typeparamref name="T"/>.
 /// </summary>
 /// <remarks>
@@ -15,7 +26,7 @@ namespace ChangeTrace.Core.Events.Semantic;
 /// </list>
 /// </remarks>
 /// <typeparam name="T">Type of event stored in the writer.</typeparam>
-public sealed class SemanticEventWriter<T>(int initialCapacity = 128) : IDisposable
+public sealed class SemanticEventWriter<T>(int initialCapacity = 128) : ISemanticEventWriter, IDisposable
 {
     private T[] _buffer = ArrayPool<T>.Shared.Rent(initialCapacity);
     private int _count = 0;

--- a/src/Rendering/Processors/TraceEventAggregationStage.cs
+++ b/src/Rendering/Processors/TraceEventAggregationStage.cs
@@ -137,7 +137,7 @@ internal sealed class TraceEventAggregationStage : IDisposable
     {
         foreach (var writer in _writers.Values)
         {
-            // ((ISemanticWriter)writer).Clear(); //todo: make interface ISemanticWriter and impl
+            ((ISemanticEventWriter)writer).Clear();
         }
 
         _commitCursor = 0;


### PR DESCRIPTION
introduce `ISemanticEventWriter` interface to standardize clearing of event writers.

- Update `SemanticEventWriter` to implement the new interface.
- Replace commented out interface invocation with concrete call to `ISemanticEventWriter.Clear`.

Result: Improves code clarity, enforces contract for writer clearing, and resolves TODO item.