### PR TITLE
Docs: add community health files and contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report a bug, regression, or unexpected behavior
+title: "[Bug]: "
+labels: [bug]
+assignees: []
+---
+
+## Summary
+
+Short description of the issue.
+
+## Expected Behavior
+
+What should happen?
+
+## Actual Behavior
+
+What happened instead?
+
+## Steps To Reproduce
+
+1. 
+2. 
+3. 
+
+## Environment
+
+- OS:
+- .NET version:
+- GPU / Driver version (if relevant):
+- ChangeTrace version / commit:
+
+## Logs / Screenshots
+
+Add logs, stack traces, screenshots, or recordings if relevant.
+
+## Additional Context
+
+Any additional details, related systems, or observations.
+
+---
+
+Please follow the [Code of Conduct](../../CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+  blank_issues_enabled: false
+  
+  contact_links:
+    - name: Code of Conduct
+      url: https://github.com/rian-be/ChangeTrace/blob/develop/CODE_OF_CONDUCT.md
+      about: Please read the community guidelines before opening an issue.
+
+    - name: Discussions
+      url: https://github.com/rian-be/ChangeTrace/discussions
+      about: Ask questions, share ideas, or discuss architecture and rendering concepts.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,48 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+title: "[Feature]: "
+labels: [feature]
+assignees: []
+---
+
+## Summary
+
+Short description of the proposed feature.
+
+## Motivation
+
+What problem does this solve?
+
+Why would this be useful?
+
+## Proposal
+
+Describe the proposed behavior, architecture, or implementation approach.
+
+## Expected Result
+
+What should the final outcome look like?
+
+## Possible Implementation Notes
+
+Optional technical ideas, constraints, or related systems.
+
+## Related Areas
+
+- [ ] Rendering
+- [ ] UI / HUD
+- [ ] Performance
+- [ ] Architecture
+- [ ] Tooling
+- [ ] Documentation
+- [ ] DX / Workflow
+- [ ] Other
+
+## Additional Context
+
+Links, screenshots, benchmarks, examples, or references.
+
+---
+
+Please follow the [Code of Conduct](../../CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,41 @@
+---
+name: Task
+about: Track a concrete implementation task
+title: "[Task]: "
+labels: [task]
+assignees: []
+---
+
+## Summary
+
+Short description of the task.
+
+## Goal
+
+Describe the expected outcome or architectural objective.
+
+## Scope
+
+What should be implemented?
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Acceptance Criteria
+
+- [ ] Feature behaves as expected
+- [ ] No regression introduced
+- [ ] Implementation follows project architecture/style
+
+## Notes
+
+Constraints, dependencies, related systems, or implementation details.
+
+## Linked Issues
+
+Related to #
+
+---
+
+Please follow the [Code of Conduct](../../CODE_OF_CONDUCT.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+Short description of the change.
+
+## Added
+
+-
+
+## Changed
+
+-
+
+## Fixed
+
+-
+
+## Result
+
+Describe the final outcome, behavior change, or architectural impact.
+
+## Testing
+
+- [ ] `dotnet build`
+- [ ] Manual testing completed
+- [ ] Existing functionality verified
+
+Additional notes:
+
+## Linked Issues
+
+
+## Checklist
+
+- [ ] PR is focused and does not include unrelated cleanup
+- [ ] Public API changes are documented
+- [ ] Breaking changes are explicitly described
+- [ ] New behavior follows existing project architecture
+- [ ] I followed the [Code of Conduct](../CODE_OF_CONDUCT.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct
+
+ChangeTrace wants a respectful, practical, and safe collaboration space for everyone.
+
+## Our Standards
+
+Examples of behavior that support a good environment:
+
+* be respectful in language and tone
+* focus on technical discussion, not personal attacks
+* assume good intent and ask for clarification first
+* accept constructive feedback
+* keep discussions relevant to the project
+
+Examples of unacceptable behavior:
+
+* harassment, discrimination, or intimidation
+* abusive or insulting language
+* doxxing or sharing private information without permission
+* repeated off-topic disruption
+* any conduct that creates an unsafe environment
+
+---
+
+## Scope
+
+This Code of Conduct applies in all project spaces, including:
+
+* issues
+* pull requests
+* code reviews
+* discussions related to ChangeTrace in public channels
+
+---
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the maintainers:
+
+* open a private channel if possible
+* include links, screenshots, and timestamps when available
+* describe what happened and what outcome you need
+
+All reports will be reviewed promptly and handled as confidentially as possible.
+
+---
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this Code of Conduct.
+
+Possible actions include:
+
+* warning
+* temporary restriction from project interaction
+* permanent removal from project spaces
+
+Actions depend on severity, pattern, and impact.
+
+---
+
+## Attribution
+
+This document is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Small and focused changes are easiest to review.
 
+Please follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Before You Start
 
 * check existing issues and pull requests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security
+
+ChangeTrace keeps repository history, timeline data, and local auth on your machine.
+
+> [!IMPORTANT]
+> Report security issues privately. Do not post exploit details in public issues.
+
+> [!WARNING]
+> This is an early experimental version. Security hardening is still in progress.
+
+## Supported Versions
+
+ChangeTrace is currently in active development.
+
+Security fixes are applied to `develop` first.
+If needed, maintainers may backport fixes to stable releases.
+
+## Reporting
+
+Please report vulnerabilities directly to maintainers through a private channel.
+
+Include:
+
+- what the issue is
+- how to reproduce it
+- what impact it has
+- affected version or commit
+- proof of concept, if available
+
+If a private channel is not available, open a minimal public issue without exploit details and request private follow-up.
+
+## Response Process
+
+Maintainers aim to:
+
+- acknowledge receipt within 7 days
+- triage and assess severity
+- prepare a fix plan based on impact
+- coordinate disclosure after a fix is available
+
+## Scope
+
+This policy applies to:
+
+- ChangeTrace CLI
+- auth/session handling
+- local storage of sensitive data
+- repository processing and export/import paths
+
+## Out of Scope
+
+The following are usually out of scope unless they create real security impact:
+
+- style or formatting issues
+- theoretical issues without reproducible path
+- issues in unsupported environments
+
+## Disclosure
+
+Please allow maintainers reasonable time to investigate and fix before public disclosure.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ChangeTrace
 
-<table width="100%">
+<table  widtxh="100%">
   <tr>
     <td align="left">
       <a href="https://learn.microsoft.com/dotnet/csharp/"><img alt="Language: C#" src="https://img.shields.io/badge/Language-C%23-239120?style=flat-square&logo=csharp&logoColor=white"></a>
@@ -75,10 +75,12 @@ For local development, replace `./changetrace` with `dotnet run --`.
 The repository is split into a few clear layers:
 
 - `src/Core` contains the event model, rules, and shared processing
+- `src/Configuration` contains app settings, converters, and service discovery helpers
 - `src/GIt` reads repositories, builds timelines, and enriches data
 - `src/CredentialTrace` handles auth, sessions, and local storage
 - `src/Rendering` builds the timeline scene and state
 - `src/Graphics` owns the rendering runtime, shaders, and GPU helpers
+- `src/Player` handles timeline playback flow and speed control
 - `src/Cli` wires commands to handlers
 - `Tools` contains repository utilities and asset maintenance scripts
 
@@ -86,24 +88,24 @@ The repository is split into a few clear layers:
 
 ChangeTrace stores local auth data under the user profile:
 
-- On Unix-like systems the data lives under `~/.changetrace/`.
+- On Unix like systems the data lives under `~/.changetrace/`.
 - On Windows it uses the equivalent user profile directory.
 - `auth.json` contains session metadata and encrypted tokens.
 - `auth.key` contains the local key used by the token store.
 
 This protects against accidental plaintext exposure in `auth.json`, but it is not a full operating-system keychain. A process running as the same user can still read both files.
 
-## Build
-
-Use the standard .NET build to verify the project:
-
-```bash
-dotnet build
-```
-
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE).
+
+## Code of Conduct
+
+Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+For vulnerability reporting, see [Security Policy](SECURITY.md).
 
 ---
 


### PR DESCRIPTION
Summary

Add GitHub community health files, issue/PR templates, and improve contributor and security documentation.

Added
    - GitHub issue templates for:
    - bug reports
    - feature requests
    - tasks
    - GitHub pull request template
    - CODE_OF_CONDUCT.md
    - SECURITY.md
    - GitHub issue configuration: - disabled blank issues - added contact/support links

Changed
     - updated README.md
     - added Code of Conduct section
     - added Security section
     - improved repository structure details
     - updated CONTRIBUTING.md
     - linked to Code of Conduct
     - improved contributor guidance

Result

The repository now has standardized issue and PR workflows, formalized community and security policies, and clearer contributor onboarding/documentatio