### PR TITLE
Feat: BenchmarkDotNet suites for render and player pipelines

### DIFF
--- a/Benchmarks/ChangeTrace.Benchmarks.csproj
+++ b/Benchmarks/ChangeTrace.Benchmarks.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ChangeTrace.csproj" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    </ItemGroup>
+
+</Project>

--- a/Benchmarks/Player/Benchmarks/EventCursorBenchmarks.cs
+++ b/Benchmarks/Player/Benchmarks/EventCursorBenchmarks.cs
@@ -1,0 +1,56 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Player.Playback;
+
+namespace ChangeTrace.Benchmarks.Player;
+
+/// <summary>
+/// Benchmarks low-level timeline cursor navigation.
+/// </summary>
+/// <remarks>
+/// Measures binary seeking and forward draining over synthetic timeline events.
+/// These operations are used by player seeking and playback tick event emission.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class EventCursorBenchmarks
+{
+    private PlayerBenchmarkFixture _fixture = null!;
+    private EventCursor _cursor = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events used by the cursor.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic player benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fixture = PlayerBenchmarkFixture.Create(EventCount);
+        _cursor = _fixture.CreateCursor();
+    }
+
+    /// <summary>
+    /// Seeks to the middle of the event stream using cursor binary search.
+    /// </summary>
+    [Benchmark]
+    public int SeekToMiddle()
+    {
+        _cursor.SeekTo(EventCount / 2.0);
+        return _cursor.Index;
+    }
+
+    /// <summary>
+    /// Drains all events forward from a fresh cursor.
+    /// </summary>
+    [Benchmark]
+    public int DrainForwardAll()
+    {
+        _cursor.ResetToStart();
+        return _cursor.DrainForward(EventCount).Count;
+    }
+}

--- a/Benchmarks/Player/Benchmarks/SeekableTimelineBenchmarks.cs
+++ b/Benchmarks/Player/Benchmarks/SeekableTimelineBenchmarks.cs
@@ -1,0 +1,59 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Player.Playback;
+
+namespace ChangeTrace.Benchmarks.Player;
+
+/// <summary>
+/// Benchmarks player seek operations.
+/// </summary>
+/// <remarks>
+/// Measures absolute and relative seek paths, including virtual clock snapping,
+/// cursor repositioning, and progress calculation.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class SeekableTimelineBenchmarks
+{
+    private PlayerBenchmarkFixture _fixture = null!;
+    private SeekableTimeline _seekable = null!;
+    private Timestamp _middle = default;
+
+    /// <summary>
+    /// Number of synthetic timeline events used by seek benchmarks.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic player benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fixture = PlayerBenchmarkFixture.Create(EventCount);
+        _seekable = _fixture.CreateSeekable();
+        _middle = Timestamp.Create(EventCount / 2).Value;
+    }
+
+    /// <summary>
+    /// Seeks to the middle of the timeline using an absolute timestamp.
+    /// </summary>
+    [Benchmark]
+    public double SeekToMiddle()
+    {
+        _seekable.Seek(_middle);
+        return _seekable.Progress;
+    }
+
+    /// <summary>
+    /// Seeks relative to the current position and returns progress.
+    /// </summary>
+    [Benchmark]
+    public double SeekRelativeSmallDelta()
+    {
+        _seekable.SeekRelative(17);
+        return _seekable.Progress;
+    }
+}

--- a/Benchmarks/Player/Benchmarks/TimelinePlayerFactoryBenchmarks.cs
+++ b/Benchmarks/Player/Benchmarks/TimelinePlayerFactoryBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+
+namespace ChangeTrace.Benchmarks.Player;
+
+/// <summary>
+/// Benchmarks creation of fully wired timeline players.
+/// </summary>
+/// <remarks>
+/// Covers factory wiring, timeline duration calculation, timeline normalization,
+/// cursor creation, seekable timeline creation, and transport setup.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class TimelinePlayerFactoryBenchmarks
+{
+    private PlayerBenchmarkFixture _fixture = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events used to create the player.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic player benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _fixture = PlayerBenchmarkFixture.Create(EventCount);
+
+    /// <summary>
+    /// Creates and disposes a fully wired timeline player.
+    /// </summary>
+    [Benchmark]
+    public double CreateTimelinePlayer()
+    {
+        using var player = _fixture.CreatePlayerFactory()
+            .Create(PlayerBenchmarkFixture.CreateTimeline(EventCount));
+
+        return player.DurationSeconds;
+    }
+}

--- a/Benchmarks/Player/Benchmarks/TimelineStepperBenchmarks.cs
+++ b/Benchmarks/Player/Benchmarks/TimelineStepperBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+
+namespace ChangeTrace.Benchmarks.Player;
+
+/// <summary>
+/// Benchmarks single-event stepping through a timeline.
+/// </summary>
+/// <remarks>
+/// Measures the cost of repeatedly calling the player stepper until all events have
+/// been emitted. This covers cursor movement and virtual clock position snapping.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class TimelineStepperBenchmarks
+{
+    private PlayerBenchmarkFixture _fixture = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events stepped through by the benchmark.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic player benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _fixture = PlayerBenchmarkFixture.Create(EventCount);
+
+    /// <summary>
+    /// Steps forward through all events in a fresh stepper.
+    /// </summary>
+    [Benchmark]
+    public int StepForwardThroughAllEvents()
+    {
+        var stepper = _fixture.CreateStepper();
+        var moved = 0;
+
+        while (stepper.StepForward().IsSuccess)
+            moved++;
+
+        return moved;
+    }
+}

--- a/Benchmarks/Player/Fixtures/PlayerBenchmarkFixture.cs
+++ b/Benchmarks/Player/Fixtures/PlayerBenchmarkFixture.cs
@@ -1,0 +1,137 @@
+using ChangeTrace.Core.Diagnostics;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Events.Info;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.Player.Factory;
+using ChangeTrace.Player.Interfaces;
+using ChangeTrace.Player.Playback;
+
+namespace ChangeTrace.Benchmarks.Player;
+
+/// <summary>
+/// Shared deterministic fixture for player benchmarks.
+/// </summary>
+/// <remarks>
+/// Creates synthetic timelines and player components without starting the timer-driven
+/// playback transport, keeping benchmarks deterministic and CPU-bound.
+/// </remarks>
+internal sealed class PlayerBenchmarkFixture
+{
+    private readonly IReadOnlyList<TraceEvent> _events;
+
+    private PlayerBenchmarkFixture(
+        int eventCount,
+        Timeline timeline,
+        IReadOnlyList<TraceEvent> events)
+    {
+        EventCount = eventCount;
+        Timeline = timeline;
+        _events = events;
+    }
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the fixture.
+    /// </summary>
+    public int EventCount { get; }
+
+    /// <summary>
+    /// Synthetic timeline used by factory-level player benchmarks.
+    /// </summary>
+    public Timeline Timeline { get; }
+
+    /// <summary>
+    /// Builds a player benchmark fixture with normalized event playback times.
+    /// </summary>
+    /// <param name="eventCount">Number of synthetic timeline events to create.</param>
+    public static PlayerBenchmarkFixture Create(int eventCount)
+    {
+        var timeline = CreateTimeline(eventCount);
+        TimelineNormalizer.Normalize(timeline, targetDurationSeconds: eventCount);
+        return new PlayerBenchmarkFixture(eventCount, timeline, timeline.Events.ToArray());
+    }
+
+    /// <summary>
+    /// Creates a fresh event cursor over the fixture events.
+    /// </summary>
+    public EventCursor CreateCursor()
+        => new(_events);
+
+    /// <summary>
+    /// Creates a fresh stepper using a new cursor and virtual clock.
+    /// </summary>
+    public TimelineStepper CreateStepper()
+        => new(CreateCursor(), CreateClock());
+
+    /// <summary>
+    /// Creates a seekable timeline over a new cursor and virtual clock.
+    /// </summary>
+    public SeekableTimeline CreateSeekable()
+        => new(CreateClock(), CreateCursor(), EventCount);
+
+    /// <summary>
+    /// Creates a player factory with no-op diagnostics.
+    /// </summary>
+    public TimelinePlayerFactory CreatePlayerFactory()
+        => new(new NoopDiagnosticsProvider());
+
+    /// <summary>
+    /// Creates a raw synthetic timeline.
+    /// </summary>
+    /// <param name="eventCount">Number of events to create.</param>
+    public static Timeline CreateTimeline(int eventCount)
+    {
+        var repository = RepositoryId.Create("bench", "player").Value;
+        var timeline = new Timeline(repository);
+        var actor = ActorName.Create("benchmark-user").Value;
+        const long baseUnix = 1_700_000_000;
+
+        for (var i = 0; i < eventCount; i++)
+        {
+            var timestamp = Timestamp.Create(baseUnix + i).Value;
+            timeline.AddEvent(new TraceEvent(
+                new TraceEventCore(
+                    timestamp,
+                    actor,
+                    $"src/module-{i % 128}/file-{i}.cs")));
+        }
+
+        return timeline;
+    }
+
+    private static VirtualClock CreateClock()
+        => new(initialSpeed: 1.0, acceleration: 1.0);
+
+    private sealed class NoopDiagnosticsProvider : IDiagnosticsProvider
+    {
+        /// <inheritdoc />
+        public MemoryMetrics GetMemoryMetrics()
+            => new(0, 0, 0);
+
+        /// <inheritdoc />
+        public int[] GetGcCollections()
+            => [0, 0, 0];
+
+        /// <inheritdoc />
+        public RuntimeMetrics GetRuntimeMetrics()
+            => new(0, 0, 0, 0);
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, double> GetCustomMetrics()
+            => new Dictionary<string, double>();
+
+        /// <inheritdoc />
+        public void RecordMetric(string key, double value)
+        {
+        }
+
+        /// <inheritdoc />
+        public void RecordEvent(string category, string label)
+        {
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<KeyValuePair<string, int>> GetTopEvents(string category, int count)
+            => [];
+    }
+}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/Benchmarks/Rendering/Benchmarks/RenderEventTranslationBenchmarks.cs
+++ b/Benchmarks/Rendering/Benchmarks/RenderEventTranslationBenchmarks.cs
@@ -1,0 +1,57 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Core.Events.Semantic;
+using ChangeTrace.Rendering.Commands;
+using ChangeTrace.Rendering.Translators;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks translation from semantic timeline events into render commands.
+/// </summary>
+/// <remarks>
+/// Measures CPU-side render event translation before commands are dispatched to the scene graph.
+/// This covers the timeline-to-render-command part of the render pipeline without OpenGL work.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class RenderEventTranslationBenchmarks
+{
+    private TranslationPipeline _pipeline = null!;
+    private CommitBundleEvent[] _events = null!;
+
+    /// <summary>
+    /// Number of synthetic semantic timeline events to translate.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic semantic event input and the default render translation pipeline.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pipeline = TranslationPipeline.Default();
+        _events = RenderBenchmarkFixture.CreateCommitBundles(EventCount);
+    }
+
+    /// <summary>
+    /// Translates all semantic events into render commands and returns total command count.
+    /// </summary>
+    [Benchmark]
+    public int TranslateCommitBundles()
+    {
+        var commandCount = 0;
+
+        foreach (var evt in _events)
+        {
+            IReadOnlyList<RenderCommand> commands =
+                _pipeline.Translate(evt);
+
+            commandCount += commands.Count;
+        }
+
+        return commandCount;
+    }
+}

--- a/Benchmarks/Rendering/Benchmarks/RenderFrameSubmissionBenchmarks.cs
+++ b/Benchmarks/Rendering/Benchmarks/RenderFrameSubmissionBenchmarks.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Rendering;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks the frame submission facade used by the renderer.
+/// </summary>
+/// <remarks>
+/// Covers <see cref="ChangeTrace.Rendering.Pipeline.RenderFrameAssembler"/> overhead,
+/// including render state assembly and submission to an <see cref="ChangeTrace.Rendering.Interfaces.IRenderOutput"/>.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class RenderFrameSubmissionBenchmarks
+{
+    private RenderBenchmarkFixture _fixture = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic render benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _fixture = RenderBenchmarkFixture.Create(EventCount);
+
+    /// <summary>
+    /// Submits one render frame to the benchmark output sink.
+    /// </summary>
+    [Benchmark]
+    public void SubmitFrame()
+    {
+        _fixture.FrameAssembler.SubmitFrame(
+            positionSeconds: 1.0,
+            deltaTime: 1.0f / 60.0f,
+            _fixture.Scene,
+            _fixture.Animation,
+            _fixture.Camera,
+            _fixture.CameraController,
+            _fixture.Diagnostics,
+            hoveredNode: null,
+            hoveredPod: null,
+            LayoutMode.SingleTree);
+    }
+}

--- a/Benchmarks/Rendering/Benchmarks/RenderStateAssemblyBenchmarks.cs
+++ b/Benchmarks/Rendering/Benchmarks/RenderStateAssemblyBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Rendering.States;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks CPU-side render state assembly.
+/// </summary>
+/// <remarks>
+/// Measures the cost of converting live scene, animation, camera, HUD, and diagnostics state
+/// into immutable <see cref="RenderState"/> snapshots before any OpenGL/GPU work starts.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class RenderStateAssemblyBenchmarks
+{
+    private RenderBenchmarkFixture _fixture = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic render benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _fixture = RenderBenchmarkFixture.Create(EventCount);
+
+    /// <summary>
+    /// Assembles a complete immutable render state snapshot.
+    /// </summary>
+    [Benchmark]
+    public int AssembleRenderState()
+    {
+        RenderState state = _fixture.AssembleRenderState();
+        return state.Scene.TotalObjects;
+    }
+}

--- a/Benchmarks/Rendering/Benchmarks/SceneFrameUpdateBenchmarks.cs
+++ b/Benchmarks/Rendering/Benchmarks/SceneFrameUpdateBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks per-frame scene simulation updates.
+/// </summary>
+/// <remarks>
+/// Measures CPU-side work done before rendering: animation ticks, edge lifetime updates,
+/// actor decay, camera updates, and layout stepping through <see cref="ChangeTrace.Rendering.Pipeline.SceneFrameUpdater"/>.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class SceneFrameUpdateBenchmarks
+{
+    private RenderBenchmarkFixture _fixture = null!;
+    private double _wallElapsedSeconds;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic render benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fixture = RenderBenchmarkFixture.Create(EventCount);
+        _wallElapsedSeconds = 1.0;
+    }
+
+    /// <summary>
+    /// Advances scene frame state by one simulated 60 FPS tick.
+    /// </summary>
+    [Benchmark]
+    public float TickFrame()
+    {
+        _wallElapsedSeconds += 1.0 / 60.0;
+        return _fixture.FrameUpdater.Tick(
+            RenderBenchmarkFixture.CreateDiagnostics(EventCount, _wallElapsedSeconds));
+    }
+}

--- a/Benchmarks/Rendering/Benchmarks/SceneSnapshotAssemblyBenchmarks.cs
+++ b/Benchmarks/Rendering/Benchmarks/SceneSnapshotAssemblyBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Rendering.Snapshots;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks immutable scene snapshot assembly.
+/// </summary>
+/// <remarks>
+/// Measures node, avatar, edge visibility, and particle snapshot generation without HUD,
+/// camera, frame submission, or OpenGL upload work.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class SceneSnapshotAssemblyBenchmarks
+{
+    private RenderBenchmarkFixture _fixture = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic render benchmark state for the current event count.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _fixture = RenderBenchmarkFixture.Create(EventCount);
+
+    /// <summary>
+    /// Assembles immutable scene snapshots for nodes, avatars, edges, and particles.
+    /// </summary>
+    [Benchmark]
+    public int AssembleSceneSnapshot()
+    {
+        SceneSnapshot snapshot = _fixture.AssembleSceneSnapshot();
+        return snapshot.TotalObjects;
+    }
+}

--- a/Benchmarks/Rendering/Fixtures/RenderBenchmarkFixture.cs
+++ b/Benchmarks/Rendering/Fixtures/RenderBenchmarkFixture.cs
@@ -1,0 +1,361 @@
+using System.Numerics;
+using ChangeTrace.Core.Diagnostics;
+using ChangeTrace.Core.Events.Semantic;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Player;
+using ChangeTrace.Player.Enums;
+using ChangeTrace.Rendering;
+using ChangeTrace.Rendering.Animation;
+using ChangeTrace.Rendering.Camera;
+using ChangeTrace.Rendering.Enums;
+using ChangeTrace.Rendering.Interfaces;
+using ChangeTrace.Rendering.Pipeline;
+using ChangeTrace.Rendering.Processors;
+using ChangeTrace.Rendering.Scene;
+using ChangeTrace.Rendering.Snapshots;
+using ChangeTrace.Rendering.States;
+using ChangeTrace.Rendering.States.Avatars;
+using ChangeTrace.Rendering.States.Edges;
+using ChangeTrace.Rendering.States.Nodes;
+using ChangeTrace.Rendering.States.Particles;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Shared deterministic fixture for CPU-side rendering benchmarks.
+/// </summary>
+/// <remarks>
+/// Creates a synthetic scene graph, animation system, camera, diagnostics snapshot,
+/// and frame pipeline components without opening OpenTK windows or requiring GPU access.
+/// </remarks>
+internal sealed class RenderBenchmarkFixture
+{
+    private readonly RenderStateAssembler _stateAssembler;
+    private readonly NodeSnapshotAssembler _nodeSnapshots = new();
+    private readonly AvatarSnapshotAssembler _avatarSnapshots = new();
+    private readonly EdgeSnapshotAssembler _edgeSnapshots = new();
+    private readonly ParticleSnapshotAssembler _particleSnapshots = new();
+
+    private RenderBenchmarkFixture(
+        int eventCount,
+        SceneGraph scene,
+        AnimationSystem animation,
+        Camera camera,
+        CameraController cameraController,
+        RenderStateAssembler stateAssembler,
+        RenderFrameAssembler frameAssembler,
+        SceneFrameUpdater frameUpdater,
+        PlayerDiagnostics diagnostics)
+    {
+        EventCount = eventCount;
+        Scene = scene;
+        Animation = animation;
+        Camera = camera;
+        CameraController = cameraController;
+        FrameAssembler = frameAssembler;
+        FrameUpdater = frameUpdater;
+        Diagnostics = diagnostics;
+        _stateAssembler = stateAssembler;
+    }
+
+    public int EventCount { get; }
+
+    /// <summary>
+    /// Synthetic scene graph populated with root, branch, file, and avatar nodes.
+    /// </summary>
+    public SceneGraph Scene { get; }
+
+    /// <summary>
+    /// Animation and particle system used by render snapshot assembly.
+    /// </summary>
+    public AnimationSystem Animation { get; }
+
+    /// <summary>
+    /// Mutable camera state used by render state assembly.
+    /// </summary>
+    public Camera Camera { get; }
+
+    /// <summary>
+    /// Camera controller used by HUD and scene frame updates.
+    /// </summary>
+    public CameraController CameraController { get; }
+
+    /// <summary>
+    /// Frame assembler under benchmark.
+    /// </summary>
+    public RenderFrameAssembler FrameAssembler { get; }
+
+    /// <summary>
+    /// Scene frame updater under benchmark.
+    /// </summary>
+    public SceneFrameUpdater FrameUpdater { get; }
+
+    /// <summary>
+    /// Baseline player diagnostics snapshot used by render assembly.
+    /// </summary>
+    public PlayerDiagnostics Diagnostics { get; }
+
+    /// <summary>
+    /// Builds a complete fixture for the requested synthetic event count.
+    /// </summary>
+    /// <param name="eventCount">Synthetic timeline event count represented by the scene.</param>
+    public static RenderBenchmarkFixture Create(int eventCount)
+    {
+        var scene = BenchmarkSceneFactory.Create(eventCount);
+        var animation = BenchmarkSceneFactory.CreateAnimation(eventCount);
+        var camera = new Camera();
+        var cameraController = new CameraController(camera);
+        var stateAssembler = new RenderStateAssembler();
+        var frameAssembler = new RenderFrameAssembler(stateAssembler, new BenchmarkRenderOutput());
+        var diagnostics = CreateDiagnostics(eventCount, wallElapsedSeconds: 1.0);
+        var frameUpdater = new SceneFrameUpdater(
+            scene,
+            animation,
+            new NoopLayoutEngine(),
+            cameraController,
+            new ActorDecaySystem(new NoopDiagnosticsProvider()),
+            viewportSize: new Vec2(1920, 1080));
+
+        return new RenderBenchmarkFixture(
+            eventCount,
+            scene,
+            animation,
+            camera,
+            cameraController,
+            stateAssembler,
+            frameAssembler,
+            frameUpdater,
+            diagnostics);
+    }
+
+    /// <summary>
+    /// Assembles a render state snapshot using the fixture state.
+    /// </summary>
+    public RenderState AssembleRenderState()
+        => _stateAssembler.Assemble(
+            virtualTime: 1.0,
+            wallDelta: 1.0 / 60.0,
+            Scene,
+            Animation,
+            Camera,
+            CameraController,
+            Diagnostics,
+            hoveredNode: null,
+            hoveredPod: null,
+            LayoutMode.SingleTree);
+
+    /// <summary>
+    /// Assembles only the immutable scene snapshot without HUD or camera state.
+    /// </summary>
+    public SceneSnapshot AssembleSceneSnapshot()
+    {
+        var nodes = _nodeSnapshots.Assemble(Scene.Nodes);
+        var avatars = _avatarSnapshots.Assemble(Scene.Avatars, out _);
+        var edges = _edgeSnapshots.Assemble(Scene);
+        var particles = _particleSnapshots.Assemble(Animation);
+
+        return new SceneSnapshot(nodes, avatars, edges, particles);
+    }
+
+    /// <summary>
+    /// Creates deterministic playback diagnostics for benchmark frame simulation.
+    /// </summary>
+    /// <param name="eventCount">Synthetic timeline event count.</param>
+    /// <param name="wallElapsedSeconds">Simulated wall-clock playback time.</param>
+    public static PlayerDiagnostics CreateDiagnostics(
+        int eventCount,
+        double wallElapsedSeconds)
+        => new(
+            State: PlayerState.Playing,
+            Mode: PlaybackMode.Once,
+            Direction: PlaybackDirection.Forward,
+            CurrentSpeed: 1.0,
+            TargetSpeed: 1.0,
+            IsRamping: false,
+            PositionSeconds: wallElapsedSeconds,
+            DurationSeconds: 100.0,
+            Progress: wallElapsedSeconds / 100.0,
+            EventsFired: Math.Min(eventCount, (int)(wallElapsedSeconds * 1000)),
+            TotalEvents: eventCount,
+            LoopCount: 0,
+            WallElapsedSeconds: wallElapsedSeconds,
+            TickCount: (int)(wallElapsedSeconds * 60.0),
+            AvgEventsPerTick: eventCount / 60.0);
+
+    /// <summary>
+    /// Creates deterministic semantic commit bundle events used to benchmark render translation.
+    /// </summary>
+    /// <param name="eventCount">Number of synthetic commit bundle events to create.</param>
+    public static CommitBundleEvent[] CreateCommitBundles(int eventCount)
+    {
+        var events = new CommitBundleEvent[eventCount];
+
+        for (var i = 0; i < eventCount; i++)
+        {
+            var fileCount = 1 + i % 5;
+            var files = new string[fileCount];
+
+            for (var fileIndex = 0; fileIndex < fileCount; fileIndex++)
+            {
+                files[fileIndex] =
+                    $"src/module-{i % 128}/feature-{fileIndex}/file-{i}-{fileIndex}.cs";
+            }
+
+            events[i] = new CommitBundleEvent(
+                commitSha: $"commit-{i:x8}",
+                actor: $"actor-{i % 128}",
+                timestamp: i,
+                files);
+        }
+
+        return events;
+    }
+
+    private sealed class BenchmarkRenderOutput : IRenderOutput
+    {
+        /// <inheritdoc />
+        public void Initialize(int width, int height)
+        {
+        }
+
+        /// <inheritdoc />
+        public void Resize(int width, int height)
+        {
+        }
+
+        /// <inheritdoc />
+        public void Submit(RenderState state)
+        {
+        }
+    }
+
+    private sealed class NoopLayoutEngine : ILayoutEngine
+    {
+        /// <inheritdoc />
+        public float Energy => 0.0f;
+
+        /// <inheritdoc />
+        public void Step(IReadOnlyDictionary<string, SceneNode> nodes, float deltaSeconds)
+        {
+        }
+    }
+
+    private sealed class NoopDiagnosticsProvider : IDiagnosticsProvider
+    {
+        /// <inheritdoc />
+        public MemoryMetrics GetMemoryMetrics()
+            => new(0, 0, 0);
+
+        /// <inheritdoc />
+        public int[] GetGcCollections()
+            => [0, 0, 0];
+
+        /// <inheritdoc />
+        public RuntimeMetrics GetRuntimeMetrics()
+            => new(0, 0, 0, 0);
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, double> GetCustomMetrics()
+            => new Dictionary<string, double>();
+
+        /// <inheritdoc />
+        public void RecordMetric(string key, double value)
+        {
+        }
+
+        /// <inheritdoc />
+        public void RecordEvent(string category, string label)
+        {
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<KeyValuePair<string, int>> GetTopEvents(string category, int count)
+            => [];
+    }
+}
+
+/// <summary>
+/// Creates synthetic render scenes for benchmark scenarios.
+/// </summary>
+/// <remarks>
+/// Scene sizes scale with the benchmark event count and are deterministic enough for
+/// repeated local comparisons while still exercising node, avatar, particle, and HUD paths.
+/// </remarks>
+internal static class BenchmarkSceneFactory
+{
+    /// <summary>
+    /// Creates a populated scene graph representing a repository at the requested scale.
+    /// </summary>
+    /// <param name="eventCount">Synthetic timeline event count used to scale scene size.</param>
+    public static SceneGraph Create(int eventCount)
+    {
+        var scene = new SceneGraph();
+        scene.GetOrCreateRoot();
+
+        var nodeCount = Math.Clamp(eventCount, 1_000, 100_000);
+        var branchCount = Math.Clamp(nodeCount / 250, 4, 400);
+
+        for (var branchIndex = 0; branchIndex < branchCount; branchIndex++)
+        {
+            var position = PositionOnCircle(branchIndex, branchCount, radius: 900);
+            scene.GetOrAddNode($"branch-{branchIndex}", NodeKind.Branch, position);
+        }
+
+        for (var i = 0; i < nodeCount; i++)
+        {
+            var branchIndex = i % branchCount;
+            var layer = i % 40;
+            var position = PositionOnCircle(i, nodeCount, radius: 1200 + layer * 4);
+            var node = scene.GetOrAddNode(
+                $"src/module-{branchIndex}/feature-{i % 64}/file-{i}.cs",
+                NodeKind.File,
+                position);
+
+            node.Glow = (i % 10) / 10.0f;
+            node.LastAuthor = $"actor-{i % 128}";
+            node.LastCommit = $"commit-{i}";
+        }
+
+        var avatarCount = Math.Clamp(eventCount / 100, 10, 1_000);
+        for (var i = 0; i < avatarCount; i++)
+        {
+            var actor = ActorName.Create($"actor-{i}").Value;
+            var avatar = scene.GetOrAddAvatar(
+                actor,
+                PositionOnCircle(i, avatarCount, radius: 600),
+                new Vector4((i % 17) / 16.0f, (i % 23) / 22.0f, (i % 31) / 30.0f, 1.0f));
+
+            avatar.ActivityLevel = 1.0f;
+            avatar.LastSeen = i;
+            avatar.TargetNodeId = $"src/module-{i % branchCount}/feature-{i % 64}/file-{i % nodeCount}.cs";
+        }
+
+        return scene;
+    }
+
+    /// <summary>
+    /// Creates an animation system with a bounded number of particle bursts.
+    /// </summary>
+    /// <param name="eventCount">Synthetic timeline event count used to scale particle bursts.</param>
+    public static AnimationSystem CreateAnimation(int eventCount)
+    {
+        var animation = new AnimationSystem();
+        var burstCount = Math.Clamp(eventCount / 1_000, 1, 20);
+
+        for (var i = 0; i < burstCount; i++)
+        {
+            animation.Burst(
+                PositionOnCircle(i, burstCount, radius: 300),
+                count: 25,
+                color: new Vector4(0.1f, 0.7f, 1.0f, 1.0f));
+        }
+
+        return animation;
+    }
+
+    private static Vec2 PositionOnCircle(int index, int count, float radius)
+    {
+        var angle = MathF.Tau * index / count;
+        return new Vec2(MathF.Cos(angle) * radius, MathF.Sin(angle) * radius);
+    }
+}

--- a/Benchmarks/Rendering/Gpu/GpuBufferData.cs
+++ b/Benchmarks/Rendering/Gpu/GpuBufferData.cs
@@ -1,0 +1,90 @@
+using System.Numerics;
+using ChangeTrace.Graphics.Gpu.Contracts;
+using ChangeTrace.Rendering;
+using ChangeTrace.Rendering.States;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// CPU-side data prepared in the same shape as renderer GPU buffers.
+/// </summary>
+/// <remarks>
+/// Used only by benchmarks to measure conversion cost before OpenGL buffer upload.
+/// </remarks>
+internal readonly record struct GpuBufferData(
+    GpuCircleNode[] Nodes,
+    GpuPawn[] Pawns,
+    GpuEdge[] Edges)
+{
+    /// <summary>
+    /// Total number of GPU contract instances prepared for a frame.
+    /// </summary>
+    public int TotalCount =>
+        Nodes.Length + Pawns.Length + Edges.Length;
+
+    /// <summary>
+    /// Builds GPU-shaped node, pawn, and edge arrays from a render state snapshot.
+    /// </summary>
+    /// <param name="state">Immutable render state used as conversion input.</param>
+    public static GpuBufferData From(RenderState state)
+    {
+        var nodes = state.Scene.Nodes;
+        var avatars = state.Scene.Avatars;
+        var edges = state.Scene.Edges;
+
+        var gpuNodes = new GpuCircleNode[nodes.Count];
+        var gpuPawns = new GpuPawn[avatars.Count];
+        var gpuEdges = new GpuEdge[edges.Count];
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            gpuNodes[i] = new GpuCircleNode
+            {
+                Position = ToVector2(node.Position),
+                Radius = node.Radius,
+                Kind = (float)node.Kind,
+                Color = node.Color,
+                Glow = node.Glow
+            };
+        }
+
+        for (var i = 0; i < avatars.Count; i++)
+        {
+            var avatar = avatars[i];
+            gpuPawns[i] = new GpuPawn
+            {
+                Position = ToVector2(avatar.Position),
+                Radius = 8.0f,
+                Alpha = avatar.Alpha,
+                Color = avatar.Color,
+                Glow = avatar.ActivityLevel
+            };
+        }
+
+        for (var i = 0; i < edges.Count; i++)
+        {
+            var edge = edges[i];
+            var from = state.Scene.FindNode(edge.FromId);
+            var to = state.Scene.FindNode(edge.ToId);
+
+            gpuEdges[i] = new GpuEdge
+            {
+                From = from is null ? Vector2.Zero : ToVector2(from.Value.Position),
+                To = to is null ? Vector2.Zero : ToVector2(to.Value.Position),
+                Color = edge.Color,
+                Alpha = edge.Alpha,
+                WidthStart = edge.WidthStart,
+                WidthEnd = edge.WidthEnd,
+                Kind = (float)edge.Kind,
+                FromGlow = from?.Glow ?? 0.0f,
+                ToGlow = to?.Glow ?? 0.0f
+            };
+        }
+
+        return new GpuBufferData(gpuNodes, gpuPawns, gpuEdges);
+    }
+
+    private static Vector2 ToVector2(Vec2 value)
+        => new(value.X, value.Y);
+}

--- a/Benchmarks/Rendering/Gpu/GpuBufferDataPreparationBenchmarks.cs
+++ b/Benchmarks/Rendering/Gpu/GpuBufferDataPreparationBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Rendering.States;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks CPU-side preparation of data shaped like GPU buffer contracts.
+/// </summary>
+/// <remarks>
+/// Measures conversion from immutable render snapshots into arrays of GPU contract structs
+/// such as nodes, actor pawns, and edges. This does not upload data to OpenGL.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class GpuBufferDataPreparationBenchmarks
+{
+    private RenderState _state = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates a prepared render state used as input for GPU data conversion.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+        => _state = RenderBenchmarkFixture.Create(EventCount).AssembleRenderState();
+
+    /// <summary>
+    /// Converts render snapshots into CPU arrays matching GPU-side contracts.
+    /// </summary>
+    [Benchmark]
+    public int PrepareGpuBufferData()
+    {
+        var data = GpuBufferData.From(_state);
+        return data.TotalCount;
+    }
+}

--- a/Benchmarks/Rendering/Layout/HiveLayoutBenchmarks.cs
+++ b/Benchmarks/Rendering/Layout/HiveLayoutBenchmarks.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Rendering.Layout.Hive.Core;
+
+namespace ChangeTrace.Benchmarks.Rendering;
+
+/// <summary>
+/// Benchmarks CPU-side hive layout computation.
+/// </summary>
+/// <remarks>
+/// Measures repository tree indexing, directory placement, heavy file cluster layout,
+/// normalization, and animated node movement without scene snapshot or OpenGL work.
+/// </remarks>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+public class HiveLayoutBenchmarks
+{
+    private RenderBenchmarkFixture _fixture = null!;
+    private HiveLayout _layout = null!;
+
+    /// <summary>
+    /// Number of synthetic timeline events represented by the generated scene.
+    /// </summary>
+    [Params(1_000, 10_000, 100_000)]
+    public int EventCount { get; set; }
+
+    /// <summary>
+    /// Creates deterministic scene state and a fresh hive layout engine.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fixture = RenderBenchmarkFixture.Create(EventCount);
+        _layout = new HiveLayout();
+    }
+
+    /// <summary>
+    /// Runs one hive layout step for the current scene.
+    /// </summary>
+    [Benchmark]
+    public float StepOnce()
+    {
+        _layout.Step(
+            _fixture.Scene.Nodes,
+            deltaSeconds: 1.0f / 60.0f);
+
+        return _layout.Energy;
+    }
+
+    /// <summary>
+    /// Runs several consecutive hive layout steps to include animated convergence cost.
+    /// </summary>
+    [Benchmark]
+    public float StepTenFrames()
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            _layout.Step(
+                _fixture.Scene.Nodes,
+                deltaSeconds: 1.0f / 60.0f);
+        }
+
+        return _layout.Energy;
+    }
+}

--- a/Benchmarks/readme.md
+++ b/Benchmarks/readme.md
@@ -1,0 +1,143 @@
+# ChangeTrace Benchmarks
+
+ChangeTrace Benchmarks contains repeatable BenchmarkDotNet scenarios for performance-sensitive CPU paths.
+
+The benchmark project exists to measure the CPU side render pipeline before OpenGL/GPU execution. It focuses on timeline event translation, layout computation, render state assembly, scene snapshot generation, visibility planning, frame preparation, and GPU buffer data preparation.
+
+> [!IMPORTANT]
+> These benchmarks are for local performance investigation and regression checks. They are not part of the normal application runtime.
+
+> [!WARNING]
+> Benchmark results depend on hardware, runtime version, operating system scheduling, power mode, and background processes. Compare results from the same machine and environment when possible.
+
+Use it when you want a repeatable way to check whether render pipeline changes affect CPU time, managed allocations, or scaling with larger timelines.
+
+The usual flow is simple:
+
+- run a focused benchmark group
+- compare execution time and allocations
+- inspect generated BenchmarkDotNet reports
+- use the results before starting deeper optimization work
+
+## What it measures
+
+The benchmark suite currently covers:
+
+- semantic render event translation from timeline events
+- hive layout computation and animated convergence
+- render state assembly from timeline events
+- scene frame update and snapshot preparation
+- isolated scene snapshot assembly
+- edge visibility planning through scene snapshot assembly
+- CPU-side GPU buffer contract preparation
+- render frame submission preparation before OpenGL upload
+
+Additional player benchmarks are available for playback cursor, seek, stepper, and player factory costs. They are kept in the same benchmark project, but the primary suite tracks issue #17 and the CPU side render pipeline.
+
+The benchmarks intentionally avoid opening OpenTK windows or requiring GPU access.
+
+## Commands
+
+Run all benchmarks:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*Benchmarks*"
+```
+
+Run the full CPU-side render pipeline suite:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*Rendering*"
+```
+
+Run render event translation benchmarks:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*RenderEventTranslationBenchmarks*"
+```
+
+Run scene snapshot assembly benchmarks:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*SceneSnapshotAssemblyBenchmarks*"
+```
+
+Run layout benchmarks:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*HiveLayoutBenchmarks*"
+```
+
+Run player benchmarks:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*Player*"
+```
+
+Run one benchmark group with a shorter sanity check:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*RenderStateAssemblyBenchmarks*" --warmupCount 1 --iterationCount 3
+```
+
+Run one player benchmark group with a shorter sanity check:
+
+```bash
+dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*EventCursorBenchmarks*" --warmupCount 1 --iterationCount 3
+```
+
+Or through Task:
+
+```bash
+task benchmark
+```
+
+## Project Structure
+
+The benchmark project is split by measured subsystem:
+
+- `Rendering/Benchmarks` contains render pipeline benchmark entry points
+- `Rendering/Fixtures` contains shared render benchmark data setup
+- `Rendering/Gpu` contains CPU-side GPU data preparation benchmarks
+- `Rendering/Layout` contains layout engine benchmarks
+- `Player/Benchmarks` contains player and playback benchmark entry points
+- `Player/Fixtures` contains shared player timeline setup
+
+The render benchmark suite maps to issue #17:
+
+- dedicated `Benchmarks/ChangeTrace.Benchmarks.csproj` project
+- BenchmarkDotNet dependency and memory diagnostics
+- `1k`, `10k`, and `100k` synthetic event sizes
+- timeline-to-render-command translation benchmark
+- hive layout benchmark
+- render state and scene snapshot assembly benchmarks
+- CPU-side GPU buffer data preparation benchmark
+- local run commands outside the normal application build flow
+
+## Reports
+
+BenchmarkDotNet writes reports under:
+
+```text
+BenchmarkDotNet.Artifacts/results/
+```
+
+The most useful files are usually:
+
+- `*-report-github.md` for pull request comments or issue updates
+- `*-report.html` for local inspection
+- `*-report.csv` for comparisons and spreadsheets
+
+## Notes
+
+Avoid `--job Dry` for performance readings. It forces very short runs and can produce misleading `MinIterationTime` warnings even when benchmarks are configured with a higher minimum iteration time.
+
+The `Failed to set up priority High` message can appear on Linux when the current user cannot raise process priority. It does not mean the benchmark failed.
+
+Real GPU/OpenTK frame benchmarking should be handled separately because results depend heavily on hardware, drivers, VSync, resolution, and windowing environment.
+
+---
+
+ChangeTrace Benchmarks are built for repeatable local performance checks before optimization work.
+
+[Back to top](#changetrace-benchmarks)

--- a/ChangeTrace.csproj
+++ b/ChangeTrace.csproj
@@ -15,7 +15,7 @@
         <PublishRepositoryUrl>false</PublishRepositoryUrl>
         
         <!-- Exclude tools folder -->
-        <DefaultItemExcludes>$(DefaultItemExcludes);Tools/**</DefaultItemExcludes>
+        <DefaultItemExcludes>$(DefaultItemExcludes);Tools/**;Benchmarks/**</DefaultItemExcludes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ChangeTrace.slnx
+++ b/ChangeTrace.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="ChangeTrace.csproj" />
+  <Project Path="Benchmarks/ChangeTrace.Benchmarks.csproj" />
   <Project Path="Tools/ChangeTrace.Tools.csproj" />
 </Solution>

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,6 +30,11 @@ tasks:
       - dotnet build {{.TOOLS_PROJECT}} -c Release --no-restore
       - dotnet run --project {{.TOOLS_PROJECT}} -- assets validate
 
+  benchmark:
+    desc: Run CPU-side render pipeline benchmarks
+    cmds:
+      - dotnet run -c Release --project Benchmarks/ChangeTrace.Benchmarks.csproj -- --filter "*Rendering*"
+
   assets:atlas:
     desc: Rebuild the language icon atlas
     cmds:

--- a/src/Configuration/AssemblyVisibility.cs
+++ b/src/Configuration/AssemblyVisibility.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ChangeTrace.Benchmarks")]


### PR DESCRIPTION
Introduce dedicated BenchmarkDotNet benchmarks for CPU side render pipeline and player performance analysis.

Added

 Benchmark project
      - Adds Benchmarks/ChangeTrace.Benchmarks.csproj
      - Adds BenchmarkDotNet dependency
      - References production ChangeTrace code from separate benchmark project
      - Keeps benchmark code excluded from normal application runtime

 Render pipeline benchmarks
      - Adds render event translation benchmark
      - Adds render state assembly benchmark
      - Adds scene snapshot assembly benchmark
      - Adds scene frame update benchmark
      - Adds render frame submission benchmark
      - Adds CPU side GPU buffer data preparation benchmark
      - Adds hive layout step and convergence benchmarks

 Player benchmarks
      - Adds event cursor seek and drain benchmarks
      - Adds seekable timeline benchmarks
      - Adds timeline stepper traversal benchmark
      - Adds timeline player factory benchmark

 Benchmark fixtures
      - Adds deterministic render benchmark fixture
      - Generates synthetic render scenes for 1k, 10k and 100k event scenarios
      - Adds deterministic player timeline fixture
      - Avoids OpenTK window creation and real GPU access

 Documentation and tooling
      - Adds benchmark README with local run commands
      - Adds task benchmark command for render pipeline benchmarks
      - Enables memory allocation diagnostics
      - Documents BenchmarkDotNet report output and runtime notes

Result

 These changes provide repeatable CPU side performance baselines for render translation, layout, snapshot assembly, GPU data preparation and player playback paths before deeper optimization work.