### PR TITLE
Test: Add CPU only regression suite and unit test project

### DIFF
--- a/ChangeTrace.csproj
+++ b/ChangeTrace.csproj
@@ -14,8 +14,8 @@
         <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
         <PublishRepositoryUrl>false</PublishRepositoryUrl>
         
-        <!-- Exclude tools folder -->
-        <DefaultItemExcludes>$(DefaultItemExcludes);Tools/**;Benchmarks/**</DefaultItemExcludes>
+        <!-- Exclude sibling projects -->
+        <DefaultItemExcludes>$(DefaultItemExcludes);Tools/**;Benchmarks/**;Tests/**</DefaultItemExcludes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,6 +24,12 @@
       <Folder Include="publish\" />
       <Folder Include="src\Core\Specifications\Filters\Merge\" />
       <Folder Include="src\Graphics\Rendering\Meshes\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+        <_Parameter1>ChangeTrace.Tests</_Parameter1>
+      </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/ChangeTrace.slnx
+++ b/ChangeTrace.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="ChangeTrace.csproj" />
+  <Project Path="Tests/ChangeTrace.Tests.csproj" />
   <Project Path="Benchmarks/ChangeTrace.Benchmarks.csproj" />
   <Project Path="Tools/ChangeTrace.Tools.csproj" />
 </Solution>

--- a/Docs/Development/Validation.md
+++ b/Docs/Development/Validation.md
@@ -4,16 +4,22 @@
 
 ```bash
 dotnet build ChangeTrace.slnx
-dotnet test Tests/ChangeTrace.Tests.csproj --no-build
+dotnet test Tests/ChangeTrace.Tests.csproj
 ```
 
 In restricted shells, `dotnet test` may need permission to create a local socket.
 
 The test project lives at:
-
+ 
 ```text
 Tests/ChangeTrace.Tests.csproj
 ```
+
+The regression suite is CPU only. It covers domain value objects, timeline
+normalization, aggregation, player state and boundary behavior, profile and
+workspace persistence, selected non-interactive CLI profile logic, and
+CPU side rendering state assembly. It must not open OpenTK windows, require GPU
+access, or run full rendering loops.
 
 ## Task
 
@@ -29,7 +35,7 @@ Useful tasks:
 | `task build` | Restore and build. |
 | `task check` | Release build, tools, and asset validation. |
 | `task benchmark` | Rendering benchmarks. |
-| `task publish` | Publish a runtime. |
+| `task publish` | Publish runtime. |
 
 ## Manual Checks
 

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using ChangeTrace.Configuration;
 using ChangeTrace.Rendering.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTK.Windowing.Desktop;
 
 namespace ChangeTrace;
 
@@ -10,6 +11,8 @@ public static class Program
 { 
     public static async Task<int> Main(string[] args)
     {
+        GLFWProvider.CheckForMainThread = false;
+
         var services = new ServiceCollection();
      //   services.ConfigureApp(logLevel: LogLevel.Information);
         services.ConfigureApp(logLevel: LogLevel.Debug);

--- a/Tests/COMMANDS.md
+++ b/Tests/COMMANDS.md
@@ -1,0 +1,35 @@
+# Test Commands
+
+Run the full regression suite:
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj
+```
+
+Run without restore when packages are already restored:
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj --no-restore
+```
+
+Run without build after a successful build:
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj --no-build
+```
+
+Run selected areas:
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~Core
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~CredentialTrace
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~Player
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~Rendering
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~GIt
+```
+
+Run a single test class:
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj --filter FullyQualifiedName~BoundaryHandlerTests
+```

--- a/Tests/ChangeTrace.Tests.csproj
+++ b/Tests/ChangeTrace.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ChangeTrace.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/ChangeTrace.Tests.csproj
+++ b/Tests/ChangeTrace.Tests.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Cli/Handlers/Profiles/Workspaces/WorkUseCommandHandlerTests.cs
+++ b/Tests/Cli/Handlers/Profiles/Workspaces/WorkUseCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using ChangeTrace.Cli.Commands.Profiles.Workspaces;
+using ChangeTrace.Cli.Handlers.Profiles.Workspaces;
+using ChangeTrace.CredentialTrace.Interfaces;
+using ChangeTrace.CredentialTrace.Profiles;
+using ChangeTrace.Tests.TestDoubles;
+using Xunit;
+
+namespace ChangeTrace.Tests.Cli.Handlers.Profiles.Workspaces;
+
+/// <summary>Tests non-interactive workspace selection logic for the work use CLI handler.</summary>
+public sealed class WorkUseCommandHandlerTests
+{
+    /// <summary>HandleAsync selects the named workspace inside the named organization.</summary>
+    [Fact]
+    public async Task HandleAsync_WithOrganizationAndWorkspaceArguments_SetsCurrentWorkspace()
+    {
+        var organization = CreateOrganization("Rian BE");
+        var workspace = WorkspaceProfile.Create(organization.Id, "Backend");
+        var context = new RecordingWorkspaceContext();
+        var handler = new WorkUseCommandHandler(
+            new InMemoryProfileStore<OrganizationProfile>(organization),
+            new InMemoryProfileStore<WorkspaceProfile>(workspace),
+            context);
+        var command = new WorkUseCommand().Build();
+        var parseResult = command.Parse(["Rian BE", "Backend"]);
+
+        await handler.HandleAsync(parseResult, CancellationToken.None);
+
+        Assert.Same(workspace, context.Current);
+    }
+
+    /// <summary>Creates an organization fixture for CLI workspace tests.</summary>
+    private static OrganizationProfile CreateOrganization(string name)
+        => new()
+        {
+            Id = Ulid.NewUlid(),
+            Name = name,
+            Provider = "github",
+            CreatedAt = DateTime.UtcNow,
+            SessionId = Ulid.NewUlid()
+        };
+
+    /// <summary>Workspace context test double that records the active workspace.</summary>
+    private sealed class RecordingWorkspaceContext : IWorkspaceContext
+    {
+        /// <summary>Currently selected workspace.</summary>
+        public WorkspaceProfile? Current { get; private set; }
+
+        /// <summary>Records the workspace passed by the handler.</summary>
+        public Task SetCurrentAsync(WorkspaceProfile workspace, CancellationToken ct = default)
+        {
+            Current = workspace;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/Core/Aggregators/CommitBundlingAggregatorTests.cs
+++ b/Tests/Core/Aggregators/CommitBundlingAggregatorTests.cs
@@ -1,0 +1,64 @@
+using ChangeTrace.Core.Aggregators;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Events.Semantic;
+using ChangeTrace.Core.Models;
+using Xunit;
+
+namespace ChangeTrace.Tests.Core.Aggregators;
+
+/// <summary>Tests commit bundle aggregation from raw trace events.</summary>
+public sealed class CommitBundlingAggregatorTests
+{
+    /// <summary>Flush emits one bundle when a commit marker closes collected file changes.</summary>
+    [Fact]
+    public void Flush_EmitsBundleForReadyCommitWithFiles()
+    {
+        using var writer = new SemanticEventWriter<CommitBundleEvent>();
+        using var aggregator = new CommitBundlingAggregator(writer);
+        var sha = CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value;
+        var timestamp = Timestamp.Create(1_735_689_600).Value;
+        var actor = ActorName.Create("rian").Value;
+
+        aggregator.Process(TraceEventFactory.FileChange(
+            timestamp,
+            actor,
+            FilePath.Create("src/Core/A.cs").Value,
+            FileChangeKind.Modified,
+            sha));
+        aggregator.Process(TraceEventFactory.FileChange(
+            timestamp,
+            actor,
+            FilePath.Create("src/Core/B.cs").Value,
+            FileChangeKind.Added,
+            sha));
+        aggregator.Process(TraceEventFactory.Commit(timestamp, actor, sha));
+
+        aggregator.Flush();
+
+        var bundles = writer.Snapshot().ToArray();
+        Assert.Single(bundles);
+        Assert.Equal(sha.Value, bundles[0].CommitSha);
+        Assert.Equal("rian", bundles[0].Actor);
+        Assert.Equal(["src/Core/A.cs", "src/Core/B.cs"], bundles[0].Files.ToArray());
+    }
+
+    /// <summary>Flush does not emit a bundle when only file changes were observed.</summary>
+    [Fact]
+    public void Flush_DoesNotEmitBundleBeforeCommitMarker()
+    {
+        using var writer = new SemanticEventWriter<CommitBundleEvent>();
+        using var aggregator = new CommitBundlingAggregator(writer);
+
+        aggregator.Process(TraceEventFactory.FileChange(
+            Timestamp.Create(1_735_689_600).Value,
+            ActorName.Create("rian").Value,
+            FilePath.Create("src/Core/A.cs").Value,
+            FileChangeKind.Modified,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value));
+
+        aggregator.Flush();
+
+        Assert.Equal(0, writer.Count);
+    }
+}

--- a/Tests/Core/Aggregators/FileCouplingAggregatorTests.cs
+++ b/Tests/Core/Aggregators/FileCouplingAggregatorTests.cs
@@ -1,0 +1,46 @@
+using ChangeTrace.Core.Aggregators;
+using ChangeTrace.Core.Events.Semantic;
+using Xunit;
+
+namespace ChangeTrace.Tests.Core.Aggregators;
+
+/// <summary>Tests file coupling event generation from commit bundles.</summary>
+public sealed class FileCouplingAggregatorTests
+{
+    /// <summary>Process emits every unique unordered file pair in a bundle.</summary>
+    [Fact]
+    public void Process_EmitsEveryUniqueFilePair()
+    {
+        using var writer = new SemanticEventWriter<FileCouplingEvent>();
+        var aggregator = new FileCouplingAggregator(writer);
+
+        aggregator.Process(new CommitBundleEvent(
+            "commit-1",
+            "rian",
+            123,
+            new[] { "a.cs", "b.cs", "c.cs" }));
+
+        var events = writer.Snapshot().ToArray();
+        Assert.Equal(3, events.Length);
+        Assert.Equal(("a.cs", "b.cs"), (events[0].FileA, events[0].FileB));
+        Assert.Equal(("a.cs", "c.cs"), (events[1].FileA, events[1].FileB));
+        Assert.Equal(("b.cs", "c.cs"), (events[2].FileA, events[2].FileB));
+    }
+
+    /// <summary>Process skips bundles that do not contain enough files to form a pair.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Process_DoesNotEmitPairsForSmallBundles(int fileCount)
+    {
+        using var writer = new SemanticEventWriter<FileCouplingEvent>();
+        var aggregator = new FileCouplingAggregator(writer);
+        var files = Enumerable.Range(0, fileCount)
+            .Select(index => $"file-{index}.cs")
+            .ToArray();
+
+        aggregator.Process(new CommitBundleEvent("commit-1", "rian", 123, files));
+
+        Assert.Equal(0, writer.Count);
+    }
+}

--- a/Tests/Core/Models/ValueObjectTests.cs
+++ b/Tests/Core/Models/ValueObjectTests.cs
@@ -1,0 +1,54 @@
+using ChangeTrace.Core.Models;
+using Xunit;
+
+namespace ChangeTrace.Tests.Core.Models;
+
+/// <summary>Tests validation and normalization rules for core value objects.</summary>
+public sealed class ValueObjectTests
+{
+    /// <summary>CommitSha.Create trims and lowercases valid SHA input.</summary>
+    [Theory]
+    [InlineData("0123456", "0123456")]
+    [InlineData("ABCDEF0123456789", "abcdef0123456789")]
+    [InlineData("  abcdef0  ", "abcdef0")]
+    public void CommitSha_Create_NormalizesValidSha(string input, string expected)
+    {
+        var result = CommitSha.Create(input);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expected, result.Value.Value);
+    }
+
+    /// <summary>CommitSha.Create rejects empty, too-short, and non-hex input.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("123456")]
+    [InlineData("not-a-sha")]
+    public void CommitSha_Create_RejectsInvalidSha(string input)
+    {
+        var result = CommitSha.Create(input);
+
+        Assert.True(result.IsFailure);
+    }
+
+    /// <summary>FilePath.Create normalizes directory separators to forward slashes.</summary>
+    [Fact]
+    public void FilePath_Create_NormalizesSeparators()
+    {
+        var result = FilePath.Create(@"src\Core\File.cs");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("src/Core/File.cs", result.Value.Value);
+    }
+
+    /// <summary>FilePath.Create rejects paths that traverse outside the repository root.</summary>
+    [Theory]
+    [InlineData("../secret.txt")]
+    [InlineData("src/../secret.txt")]
+    public void FilePath_Create_RejectsTraversal(string path)
+    {
+        var result = FilePath.Create(path);
+
+        Assert.True(result.IsFailure);
+    }
+}

--- a/Tests/Core/Serialization/GenericTimelineSerializerTests.cs
+++ b/Tests/Core/Serialization/GenericTimelineSerializerTests.cs
@@ -1,0 +1,73 @@
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Services;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Dto;
+using ChangeTrace.GIt.Services;
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+
+namespace ChangeTrace.Tests.Core.Serialization;
+
+/// <summary>Tests generic timeline serialization with current and legacy payloads.</summary>
+public sealed class GenericTimelineSerializerTests
+{
+    /// <summary>RoundTrip serializes and deserializes a timeline through the generic serializer.</summary>
+    [Fact]
+    public async Task RoundTrip_UsesGenericTimelineSerializer()
+    {
+        var serializer = new MessagePackSerializer<Timeline>(
+            [new TimelineMessagePackFormatter()]);
+
+        var timeline = CreateTimeline();
+
+        var bytes = await serializer.SerializeAsync(timeline);
+        var deserialized = await serializer.DeserializeAsync(bytes);
+
+        AssertTimeline(deserialized);
+    }
+
+    /// <summary>DeserializeAsync reads the legacy compressed TimelineDto payload format.</summary>
+    [Fact]
+    public async Task DeserializeAsync_ReadsLegacyCompressedTimelineDtoPayload()
+    {
+        var legacyOptions = MessagePackSerializerOptions.Standard
+            .WithCompression(MessagePackCompression.Lz4BlockArray)
+            .WithResolver(StandardResolverAllowPrivate.Instance);
+        var legacyBytes = MessagePackSerializer.Serialize(
+            TimelineDto.FromDomain(CreateTimeline()),
+            legacyOptions);
+        var serializer = new MessagePackSerializer<Timeline>(
+            [new TimelineMessagePackFormatter()]);
+
+        var deserialized = await serializer.DeserializeAsync(legacyBytes);
+
+        AssertTimeline(deserialized);
+    }
+
+    /// <summary>Creates a timeline containing one file-change event for serializer assertions.</summary>
+    private static Timeline CreateTimeline()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        timeline.AddEvent(TraceEventFactory.FileChange(
+            Timestamp.Create(1_735_689_600).Value,
+            ActorName.Create("rian").Value,
+            FilePath.Create("src/Core/Timelines/TImeline.cs").Value,
+            FileChangeKind.Modified,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Update timeline"));
+        return timeline;
+    }
+
+    /// <summary>Asserts the repository and event fields preserved by serialization.</summary>
+    private static void AssertTimeline(Timeline deserialized)
+    {
+        Assert.Equal("rian-be", deserialized.RepositoryId?.Owner);
+        Assert.Equal("ChangeTrace", deserialized.RepositoryId?.Name);
+        Assert.Single(deserialized.Events);
+        Assert.Equal("rian", deserialized.Events[0].Core.Actor.Value);
+        Assert.Equal("src/Core/Timelines/TImeline.cs", deserialized.Events[0].Metadata?.FilePath?.Value);
+    }
+}

--- a/Tests/Core/Timelines/TimelineNormalizerTests.cs
+++ b/Tests/Core/Timelines/TimelineNormalizerTests.cs
@@ -1,0 +1,46 @@
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Timelines;
+using Xunit;
+
+namespace ChangeTrace.Tests.Core.Timelines;
+
+/// <summary>Tests timeline ordering and relative-time normalization.</summary>
+public sealed class TimelineNormalizerTests
+{
+    /// <summary>Normalize sorts events by timestamp and maps them into the requested duration.</summary>
+    [Fact]
+    public void Normalize_SortsEventsAndComputesRelativeTime()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        timeline.AddEvent(CreateCommit(300));
+        timeline.AddEvent(CreateCommit(100));
+        timeline.AddEvent(CreateCommit(200));
+
+        var result = TimelineNormalizer.Normalize(timeline, targetDurationSeconds: 20);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal([100, 200, 300], timeline.Events.Select(evt => evt.Core.Timestamp.UnixSeconds).ToArray());
+        Assert.Equal([0, 10, 20], timeline.Events.Select(evt => evt.RelativeTime?.TotalSeconds).ToArray());
+    }
+
+    /// <summary>Normalize returns a failure result for a timeline without events.</summary>
+    [Fact]
+    public void Normalize_FailsForEmptyTimeline()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+
+        var result = TimelineNormalizer.Normalize(timeline);
+
+        Assert.True(result.IsFailure);
+    }
+
+    /// <summary>Creates a commit event at a fixed Unix timestamp for normalization tests.</summary>
+    private static TraceEvent CreateCommit(long timestamp)
+        => TraceEventFactory.Commit(
+            Timestamp.Create(timestamp).Value,
+            ActorName.Create("rian").Value,
+            CommitSha.Create($"{timestamp:x40}").Value,
+            $"Commit {timestamp}");
+}

--- a/Tests/CredentialTrace/Profiles/WorkspaceProfileTests.cs
+++ b/Tests/CredentialTrace/Profiles/WorkspaceProfileTests.cs
@@ -1,0 +1,40 @@
+using ChangeTrace.CredentialTrace.Profiles;
+using Xunit;
+
+namespace ChangeTrace.Tests.CredentialTrace.Profiles;
+
+/// <summary>Tests workspace profile creation and settings updates.</summary>
+public sealed class WorkspaceProfileTests
+{
+    /// <summary>Create assigns identity, organization ownership, settings, and timestamp defaults.</summary>
+    [Fact]
+    public void Create_InitializesDefaults()
+    {
+        var organizationId = Ulid.NewUlid();
+
+        var workspace = WorkspaceProfile.Create(organizationId, "Backend");
+
+        Assert.NotEqual(default, workspace.Id);
+        Assert.Equal(organizationId, workspace.OrganizationId);
+        Assert.Equal("Backend", workspace.Name);
+        Assert.NotNull(workspace.Settings);
+        Assert.True(workspace.CreatedAt <= DateTime.UtcNow);
+    }
+
+    /// <summary>UpdateSettings replaces the workspace settings instance.</summary>
+    [Fact]
+    public void UpdateSettings_ReplacesSettings()
+    {
+        var workspace = WorkspaceProfile.Create(Ulid.NewUlid(), "Backend");
+        var settings = new WorkspaceSettings
+        {
+            DefaultBranch = "develop",
+            AutoSync = false,
+            Environment = "prod"
+        };
+
+        workspace.UpdateSettings(settings);
+
+        Assert.Same(settings, workspace.Settings);
+    }
+}

--- a/Tests/CredentialTrace/Services/AuthServiceTests.cs
+++ b/Tests/CredentialTrace/Services/AuthServiceTests.cs
@@ -1,0 +1,102 @@
+using ChangeTrace.CredentialTrace;
+using ChangeTrace.CredentialTrace.Interfaces;
+using ChangeTrace.CredentialTrace.Services;
+using Xunit;
+
+namespace ChangeTrace.Tests.CredentialTrace.Services;
+
+/// <summary>Tests authenticated session reuse, validation, and replacement behavior.</summary>
+public sealed class AuthServiceTests
+{
+    /// <summary>FetchSession returns an existing valid session without invoking provider login.</summary>
+    [Fact]
+    public async Task FetchSession_ReturnsExistingValidSessionWithoutLogin()
+    {
+        var existing = AuthSession.Create("github", "valid-token", "rian");
+        var store = new InMemoryTokenStore(existing);
+        var provider = new TestAuthProvider("github", AuthSession.Create("github", "new-token"), isValid: true);
+        var service = new AuthService([provider], store);
+
+        var session = await service.FetchSession("GitHub");
+
+        Assert.Same(existing, session);
+        Assert.Equal(0, provider.LoginCount);
+    }
+
+    /// <summary>FetchSession removes an invalid stored session and persists the provider login result.</summary>
+    [Fact]
+    public async Task FetchSession_RemovesInvalidSessionAndPersistsNewLogin()
+    {
+        var existing = AuthSession.Create("github", "expired-token", "rian");
+        var replacement = AuthSession.Create("github", "fresh-token", "rian");
+        var store = new InMemoryTokenStore(existing);
+        var provider = new TestAuthProvider("github", replacement, isValid: false);
+        var service = new AuthService([provider], store);
+
+        var session = await service.FetchSession("github");
+
+        Assert.Same(replacement, session);
+        Assert.Equal(1, provider.LoginCount);
+        Assert.Same(replacement, await store.GetAsync("github"));
+        Assert.Equal(["github"], store.RemovedProviders);
+    }
+
+    /// <summary>Test auth provider that records login calls and returns a configurable validation result.</summary>
+    private sealed class TestAuthProvider(
+        string name,
+        AuthSession loginSession,
+        bool isValid)
+        : IValidatableAuthProvider
+    {
+        /// <summary>Provider name matched by AuthService.</summary>
+        public string Name { get; } = name;
+
+        /// <summary>Number of times LoginAsync was invoked.</summary>
+        public int LoginCount { get; private set; }
+
+        /// <summary>Returns the configured login session and increments LoginCount.</summary>
+        public Task<AuthSession> LoginAsync(CancellationToken ct = default)
+        {
+            LoginCount++;
+            return Task.FromResult(loginSession);
+        }
+
+        /// <summary>Returns the configured validation result for any token.</summary>
+        public Task<bool> ValidateTokenAsync(string token, CancellationToken ct = default)
+            => Task.FromResult(isValid);
+    }
+
+    /// <summary>In-memory token store used to assert AuthService persistence behavior.</summary>
+    private sealed class InMemoryTokenStore(params AuthSession[] sessions) : ITokenStore
+    {
+        private readonly Dictionary<string, AuthSession> _sessions = sessions.ToDictionary(
+            session => session.Provider,
+            StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Providers removed through RemoveAsync, in call order.</summary>
+        public List<string> RemovedProviders { get; } = [];
+
+        /// <summary>Saves or replaces <paramref name="session"/> by provider.</summary>
+        public Task SaveAsync(AuthSession session, CancellationToken ct = default)
+        {
+            _sessions[session.Provider] = session;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Returns the session stored for provider, if present.</summary>
+        public Task<AuthSession?> GetAsync(string provider, CancellationToken ct = default)
+            => Task.FromResult(_sessions.GetValueOrDefault(provider));
+
+        /// <summary>Returns all sessions currently stored in memory.</summary>
+        public Task<IReadOnlyList<AuthSession>> ListAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AuthSession>>(_sessions.Values.ToArray());
+
+        /// <summary>Removes a provider session and records the provider name.</summary>
+        public Task RemoveAsync(string provider, CancellationToken ct = default)
+        {
+            RemovedProviders.Add(provider);
+            _sessions.Remove(provider);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/CredentialTrace/Services/WorkspaceContextFileStoreTests.cs
+++ b/Tests/CredentialTrace/Services/WorkspaceContextFileStoreTests.cs
@@ -1,0 +1,120 @@
+using ChangeTrace.Core.Interfaces;
+using ChangeTrace.CredentialTrace.Profiles;
+using ChangeTrace.CredentialTrace.Services;
+using ChangeTrace.Tests.TestDoubles;
+using Xunit;
+
+namespace ChangeTrace.Tests.CredentialTrace.Services;
+
+/// <summary>Tests active workspace persistence through WorkspaceContextFileStore.</summary>
+public sealed class WorkspaceContextFileStoreTests
+{
+    /// <summary>SetCurrentAsync updates Current and persists the workspace id.</summary>
+    [Fact]
+    public async Task SetCurrentAsync_UpdatesCurrentAndPersistsWorkspaceId()
+    {
+        var workspace = WorkspaceProfile.Create(Ulid.NewUlid(), "Backend");
+        var fileManager = new InMemoryFileManager();
+        var serializer = new UlidTestSerializer();
+        var context = new WorkspaceContextFileStore(
+            fileManager,
+            new InMemoryProfileStore<WorkspaceProfile>(workspace),
+            serializer);
+
+        await context.SetCurrentAsync(workspace);
+
+        Assert.Same(workspace, context.Current);
+        Assert.Equal(".changetrace/current_workspace.json", fileManager.SavedPath);
+        Assert.Equal(workspace.Id.ToString(), serializer.SerializedValue?.ToString());
+    }
+
+    /// <summary>Constructor loads an existing workspace id and resolves it from the profile store.</summary>
+    [Fact]
+    public void Constructor_LoadsCurrentWorkspaceWhenConfigExists()
+    {
+        var workspace = WorkspaceProfile.Create(Ulid.NewUlid(), "Backend");
+        var serializer = new UlidTestSerializer { DeserializedValue = workspace.Id };
+        var fileManager = new InMemoryFileManager
+        {
+            ExistingPath = ".changetrace/current_workspace.json",
+            BytesToLoad = [1, 2, 3]
+        };
+
+        var context = new WorkspaceContextFileStore(
+            fileManager,
+            new InMemoryProfileStore<WorkspaceProfile>(workspace),
+            serializer);
+
+        Assert.Same(workspace, context.Current);
+        Assert.Equal(".changetrace/current_workspace.json", fileManager.LoadedPath);
+    }
+
+    /// <summary>File manager test double for current-workspace config access.</summary>
+    private sealed class InMemoryFileManager : IFileManager
+    {
+        /// <summary>Path treated as existing by Exists.</summary>
+        public string? ExistingPath { get; init; }
+
+        /// <summary>Bytes returned by LoadAsync.</summary>
+        public byte[] BytesToLoad { get; init; } = [];
+
+        /// <summary>Path passed to SaveAsync.</summary>
+        public string? SavedPath { get; private set; }
+
+        /// <summary>Bytes passed to SaveAsync.</summary>
+        public byte[]? SavedBytes { get; private set; }
+
+        /// <summary>Path passed to LoadAsync.</summary>
+        public string? LoadedPath { get; private set; }
+
+        /// <summary>Records saved bytes.</summary>
+        public Task SaveAsync(string path, byte[] data, CancellationToken cancellationToken = default)
+        {
+            SavedPath = path;
+            SavedBytes = data;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Records load path and returns configured bytes.</summary>
+        public Task<byte[]> LoadAsync(string path, CancellationToken cancellationToken = default)
+        {
+            LoadedPath = path;
+            return Task.FromResult(BytesToLoad);
+        }
+
+        /// <summary>Returns true only for configured existing path.</summary>
+        public bool Exists(string path) => path == ExistingPath;
+
+        /// <summary>Returns fallback text for unsupported text reads.</summary>
+        public Task<string> ReadAllTextAsync(string path, string fallback = "", CancellationToken ct = default)
+            => Task.FromResult(fallback);
+
+        /// <summary>Ensures a suffix extension on a path.</summary>
+        public string EnsureExtension(string path, string extension)
+            => path.EndsWith(extension, StringComparison.OrdinalIgnoreCase) ? path : path + extension;
+
+        /// <summary>Returns no files for unsupported file discovery.</summary>
+        public IEnumerable<string> FindFiles(string directory, string extension) => [];
+    }
+
+    /// <summary>Ulid serializer test double for active workspace ids.</summary>
+    private sealed class UlidTestSerializer : ISerializer<Ulid>
+    {
+        /// <summary>Value passed to SerializeAsync.</summary>
+        public Ulid? SerializedValue { get; private set; }
+
+        /// <summary>Value returned by DeserializeAsync.</summary>
+        public Ulid DeserializedValue { get; init; }
+
+        /// <summary>Records serialized value and returns deterministic bytes.</summary>
+        public Task<byte[]> SerializeAsync(Ulid obj, CancellationToken ct = default)
+        {
+            SerializedValue = obj;
+            return Task.FromResult<byte[]>([4, 5, 6]);
+        }
+
+        /// <summary>Returns the configured deserialized value.</summary>
+        public Task<Ulid> DeserializeAsync(byte[] data, CancellationToken ct = default)
+            => Task.FromResult(DeserializedValue);
+    }
+}

--- a/Tests/CredentialTrace/Services/WorkspaceStoreTests.cs
+++ b/Tests/CredentialTrace/Services/WorkspaceStoreTests.cs
@@ -1,0 +1,54 @@
+using ChangeTrace.CredentialTrace.Profiles;
+using ChangeTrace.CredentialTrace.Services;
+using ChangeTrace.Tests.TestDoubles;
+using Xunit;
+
+namespace ChangeTrace.Tests.CredentialTrace.Services;
+
+/// <summary>Tests workspace lookup behavior across organization-backed profile stores.</summary>
+public sealed class WorkspaceStoreTests
+{
+    /// <summary>GetByNameOrganization returns workspaces for the named organization ordered by name.</summary>
+    [Fact]
+    public async Task GetByNameOrganization_ReturnsMatchingWorkspacesOrderedByName()
+    {
+        var organization = CreateOrganization("Rian BE");
+        var otherOrganization = CreateOrganization("Other");
+        var beta = WorkspaceProfile.Create(organization.Id, "Beta");
+        var alpha = WorkspaceProfile.Create(organization.Id, "Alpha");
+        var outside = WorkspaceProfile.Create(otherOrganization.Id, "Outside");
+        var store = new WorkspaceStore(
+            new InMemoryProfileStore<OrganizationProfile>(organization, otherOrganization),
+            new InMemoryProfileStore<WorkspaceProfile>(beta, outside, alpha));
+
+        var workspaces = await store.GetByNameOrganization("rian be");
+
+        Assert.Equal(["Alpha", "Beta"], workspaces.Select(workspace => workspace.Name).ToArray());
+    }
+
+    /// <summary>GetByNameOrganization returns an empty list for blank or unknown organization names.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("missing")]
+    public async Task GetByNameOrganization_ReturnsEmptyForBlankOrUnknownOrganization(string organizationName)
+    {
+        var store = new WorkspaceStore(
+            new InMemoryProfileStore<OrganizationProfile>(),
+            new InMemoryProfileStore<WorkspaceProfile>());
+
+        var workspaces = await store.GetByNameOrganization(organizationName);
+
+        Assert.Empty(workspaces);
+    }
+
+    /// <summary>Creates an organization fixture with the supplied name.</summary>
+    private static OrganizationProfile CreateOrganization(string name)
+        => new()
+        {
+            Id = Ulid.NewUlid(),
+            Name = name,
+            Provider = "github",
+            CreatedAt = DateTime.UtcNow,
+            SessionId = Ulid.NewUlid()
+        };
+}

--- a/Tests/CredentialTrace/Services/WorkspaceTimelineStorageTests.cs
+++ b/Tests/CredentialTrace/Services/WorkspaceTimelineStorageTests.cs
@@ -1,0 +1,104 @@
+using ChangeTrace.CredentialTrace.Profiles;
+using ChangeTrace.CredentialTrace.Services;
+using ChangeTrace.Tests.TestDoubles;
+using Xunit;
+
+namespace ChangeTrace.Tests.CredentialTrace.Services;
+
+/// <summary>Tests workspace timeline path generation and metadata discovery.</summary>
+public sealed class WorkspaceTimelineStorageTests
+{
+    /// <summary>CreateTimelinePathAsync builds a stable organization/workspace/repository timeline path.</summary>
+    [Fact]
+    public async Task CreateTimelinePath_UsesOrganizationWorkspaceRepositoryAndUniqueFileName()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "ChangeTrace.Tests");
+        var organization = CreateOrganization("Microsoft");
+        var workspace = WorkspaceProfile.Create(organization.Id, "MsQuic");
+        var storage = new WorkspaceTimelineStorage(root, new InMemoryProfileStore<OrganizationProfile>(organization));
+        var exportedAt = new DateTimeOffset(2026, 5, 30, 12, 34, 56, TimeSpan.Zero);
+
+        var path = await storage.CreateTimelinePathAsync(
+            workspace,
+            "https://github.com/microsoft/msquic.git",
+            exportedAt,
+            "01JY0000000000000000000000");
+
+        var expected = Path.Combine(
+            root,
+            "workspaces",
+            "microsoft",
+            "msquic",
+            "timelines",
+            "microsoft-msquic",
+            "20260530T123456Z-01jy0000000000000000000000.gittrace");
+
+        Assert.Equal(expected, path);
+    }
+
+    /// <summary>CreateTimelinePathAsync derives the repository slug from a local repository path.</summary>
+    [Fact]
+    public async Task CreateTimelinePath_UsesLocalRepositoryNameWhenSourceIsPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "ChangeTrace.Tests");
+        var organization = CreateOrganization("Local Org");
+        var workspace = WorkspaceProfile.Create(organization.Id, "Local Workspace");
+        var storage = new WorkspaceTimelineStorage(root, new InMemoryProfileStore<OrganizationProfile>(organization));
+        var exportedAt = new DateTimeOffset(2026, 5, 30, 12, 34, 56, TimeSpan.Zero);
+
+        var path = await storage.CreateTimelinePathAsync(
+            workspace,
+            "/tmp/repos/My Repo.git",
+            exportedAt,
+            "export-1");
+
+        Assert.EndsWith(
+            Path.Combine(
+                "workspaces",
+                "local-org",
+                "local-workspace",
+                "timelines",
+                "my-repo",
+                "20260530T123456Z-export-1.gittrace"),
+            path);
+    }
+
+    /// <summary>Saved metadata is returned with the matching workspace timeline listing.</summary>
+    [Fact]
+    public async Task SaveMetadataAndListTimelines_ReturnsTimelineWithMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "ChangeTrace.Tests", Ulid.NewUlid().ToString());
+        var organization = CreateOrganization("Rian BE");
+        var workspace = WorkspaceProfile.Create(organization.Id, "Prod");
+        var storage = new WorkspaceTimelineStorage(root, new InMemoryProfileStore<OrganizationProfile>(organization));
+        var exportedAt = new DateTimeOffset(2026, 6, 3, 18, 45, 0, TimeSpan.Zero);
+        var path = await storage.CreateTimelinePathAsync(
+            workspace,
+            "git@github.com:rian-be/ChangeTrace.git",
+            exportedAt,
+            "export-1");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, "gittrace");
+        await storage.SaveMetadataAsync(path, workspace, "git@github.com:rian-be/ChangeTrace.git", exportedAt);
+
+        var timelines = await storage.ListTimelinesAsync(workspace);
+
+        var timeline = Assert.Single(timelines);
+        Assert.Equal(path, timeline.Path);
+        Assert.Equal("rian-be", timeline.Metadata?.RepositoryOwner);
+        Assert.Equal("ChangeTrace", timeline.Metadata?.RepositoryName);
+        Assert.Equal(exportedAt, timeline.Metadata?.ExportedAtUtc);
+    }
+
+    /// <summary>Creates a GitHub organization profile fixture with the supplied display name.</summary>
+    private static OrganizationProfile CreateOrganization(string name)
+        => new()
+        {
+            Id = Ulid.NewUlid(),
+            Name = name,
+            Provider = "github",
+            CreatedAt = DateTime.UtcNow,
+            SessionId = Ulid.NewUlid()
+        };
+}

--- a/Tests/GIt/Dto/TimelineDtoTests.cs
+++ b/Tests/GIt/Dto/TimelineDtoTests.cs
@@ -1,0 +1,134 @@
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Dto;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Dto;
+
+/// <summary>Tests Git timeline DTO conversion to and from domain timelines.</summary>
+public sealed class TimelineDtoTests
+{
+    /// <summary>FromDomain preserves repository identity, event data, and normalized ordering state.</summary>
+    [Fact]
+    public void FromDomain_CopiesRepositoryEventsAndNormalizedState()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        timeline.AddEvent(CreateCommit(100));
+        timeline.AddEvent(CreateFileChange(200));
+
+        var dto = TimelineDto.FromDomain(timeline);
+
+        Assert.NotNull(dto.RepositoryId);
+        Assert.Equal("rian-be", dto.RepositoryId.Owner);
+        Assert.Equal("ChangeTrace", dto.RepositoryId.Name);
+        Assert.True(dto.IsNormalized);
+        Assert.Equal(2, dto.Events.Count);
+        Assert.Equal("0123456789abcdef0123456789abcdef01234567", dto.Events[1].CommitSha);
+        Assert.Equal("src/GIt/Services/GitRepositoryReader.cs", dto.Events[1].FilePath);
+        Assert.Equal(FileChangeKind.Modified.ToString(), dto.Events[1].CommitType);
+    }
+
+    /// <summary>FromDomain marks a DTO as not normalized when event timestamps move backward.</summary>
+    [Fact]
+    public void FromDomain_MarksTimelineAsNotNormalizedWhenEventsAreOutOfOrder()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        timeline.AddEvent(CreateCommit(200));
+        timeline.AddEvent(CreateCommit(100));
+
+        var dto = TimelineDto.FromDomain(timeline);
+
+        Assert.False(dto.IsNormalized);
+    }
+
+    /// <summary>ToDomain rebuilds repository identity and supported event shapes from DTO data.</summary>
+    [Fact]
+    public void ToDomain_RebuildsRepositoryAndSupportedEvents()
+    {
+        var dto = new TimelineDto
+        {
+            RepositoryId = new RepositoryIdDto("rian-be", "ChangeTrace"),
+            Events =
+            [
+                TraceEventDto.FromDomain(CreateCommit(100)),
+                TraceEventDto.FromDomain(CreateFileChange(200)),
+                TraceEventDto.FromDomain(CreateBranch(300)),
+                TraceEventDto.FromDomain(CreateMerge(400))
+            ],
+            IsNormalized = true
+        };
+
+        var timeline = dto.ToDomain();
+
+        Assert.Equal("rian-be", timeline.RepositoryId?.Owner);
+        Assert.Equal("ChangeTrace", timeline.RepositoryId?.Name);
+        Assert.Equal(4, timeline.Events.Count);
+        Assert.Equal("Initial commit", timeline.Events[0].Metadata?.Metadata);
+        Assert.Equal("src/GIt/Services/GitRepositoryReader.cs", timeline.Events[1].Metadata?.FilePath?.Value);
+        Assert.Equal(BranchEventType.BranchCreated, timeline.Events[2].Branch?.Type);
+        Assert.Equal(BranchEventType.Merge, timeline.Events[3].Branch?.Type);
+    }
+
+    /// <summary>ToDomain skips events that cannot be rebuilt from invalid DTO values.</summary>
+    [Fact]
+    public void ToDomain_SkipsInvalidEvents()
+    {
+        var dto = new TimelineDto
+        {
+            Events =
+            [
+                new TraceEventDto
+                {
+                    Timestamp = 100,
+                    Actor = "rian",
+                    CommitSha = "not-a-sha"
+                },
+                TraceEventDto.FromDomain(CreateCommit(200))
+            ]
+        };
+
+        var timeline = dto.ToDomain();
+
+        var evt = Assert.Single(timeline.Events);
+        Assert.Equal(200, evt.Core.Timestamp.UnixSeconds);
+    }
+
+    /// <summary>Creates commit event for DTO conversion tests.</summary>
+    private static TraceEvent CreateCommit(long timestamp)
+        => TraceEventFactory.Commit(
+            Timestamp.Create(timestamp).Value,
+            ActorName.Create("rian").Value,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Initial commit");
+
+    /// <summary>Creates file change event for DTO conversion tests.</summary>
+    private static TraceEvent CreateFileChange(long timestamp)
+        => TraceEventFactory.FileChange(
+            Timestamp.Create(timestamp).Value,
+            ActorName.Create("rian").Value,
+            FilePath.Create("src/GIt/Services/GitRepositoryReader.cs").Value,
+            FileChangeKind.Modified,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Update reader");
+
+    /// <summary>Creates branch event for DTO conversion tests.</summary>
+    private static TraceEvent CreateBranch(long timestamp)
+        => TraceEventFactory.Branch(
+            Timestamp.Create(timestamp).Value,
+            ActorName.Create("rian").Value,
+            BranchName.Create("feature/git-tests").Value,
+            BranchEventType.BranchCreated,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Create branch");
+
+    /// <summary>Creates merge event for DTO conversion tests.</summary>
+    private static TraceEvent CreateMerge(long timestamp)
+        => TraceEventFactory.Merge(
+            Timestamp.Create(timestamp).Value,
+            ActorName.Create("rian").Value,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            BranchName.Create("main").Value,
+            "Merge feature");
+}

--- a/Tests/GIt/Enrichers/BasePlatformEnricherTests.cs
+++ b/Tests/GIt/Enrichers/BasePlatformEnricherTests.cs
@@ -1,0 +1,76 @@
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Enrichers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Enrichers;
+
+/// <summary>Tests common platform enricher behavior shared by Git hosting integrations.</summary>
+public sealed class BasePlatformEnricherTests
+{
+    /// <summary>MapPrState maps merged pull requests before considering their textual state.</summary>
+    [Theory]
+    [InlineData(true, "open", "PullRequestMerged")]
+    [InlineData(false, "closed", "PullRequestClosed")]
+    [InlineData(false, "open", "PullRequestCreated")]
+    [InlineData(false, "OPEN", "PullRequestCreated")]
+    public void MapPrState_MapsMergedClosedAndOpenStates(
+        bool merged,
+        string state,
+        string expected)
+    {
+        var actual = TestPlatformEnricher.Map(merged, state);
+
+        Assert.Equal(expected, actual.ToString());
+    }
+
+    /// <summary>EnrichTraceEventWithPr returns an event with pull request data and merged metadata.</summary>
+    [Fact]
+    public void EnrichTraceEventWithPr_AttachesPullRequestAndMetadata()
+    {
+        var enricher = new TestPlatformEnricher();
+        var traceEvent = TraceEventFactory.Commit(
+            Timestamp.Create(1_735_689_600).Value,
+            ActorName.Create("rian").Value,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Original metadata");
+
+        var enriched = enricher.Enrich(
+            traceEvent,
+            42,
+            PullRequestEventType.PullRequestMerged,
+            "PR#42 by rian -> main");
+
+        Assert.Equal(42, enriched.PullRequest?.Number.Value);
+        Assert.Equal(PullRequestEventType.PullRequestMerged, enriched.PullRequest?.Type);
+        Assert.Equal("PR#42 by rian -> main", enriched.Metadata?.Metadata);
+    }
+
+    /// <summary>Test subclass exposing protected helper methods without platform I/O.</summary>
+    private sealed class TestPlatformEnricher()
+        : BasePlatformEnricher(NullLogger<TestPlatformEnricher>.Instance)
+    {
+        /// <summary>Exposes the protected PR state mapper.</summary>
+        public static PullRequestEventType Map(bool merged, string state)
+            => MapPrState(merged, state);
+
+        /// <summary>Exposes the protected event enrichment helper.</summary>
+        public TraceEvent Enrich(
+            TraceEvent traceEvent,
+            int prNumber,
+            PullRequestEventType prType,
+            string metadata)
+            => EnrichTraceEventWithPr(traceEvent, prNumber, prType, metadata);
+
+        /// <summary>Completes the abstract contract without external platform calls.</summary>
+        public override Task<Result<EnrichmentResult>> EnrichAsync(
+            Timeline timeline,
+            RepositoryId repositoryId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Result<EnrichmentResult>.Success(new EnrichmentResult(0, 0, 0)));
+    }
+}

--- a/Tests/GIt/Helpers/ProviderUrlHelperTests.cs
+++ b/Tests/GIt/Helpers/ProviderUrlHelperTests.cs
@@ -1,0 +1,52 @@
+using ChangeTrace.GIt.Helpers;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Helpers;
+
+/// <summary>Tests Git provider detection from repository URLs.</summary>
+public sealed class ProviderUrlHelperTests
+{
+    /// <summary>DetectProvider resolves GitHub from HTTPS, HTTP, and SSH repository formats.</summary>
+    [Theory]
+    [InlineData("https://github.com/rian-be/ChangeTrace.git")]
+    [InlineData("http://github.com/rian-be/ChangeTrace")]
+    [InlineData("git@github.com:rian-be/ChangeTrace.git")]
+    public void DetectProvider_ReturnsGithubForSupportedGitHubFormats(string repository)
+    {
+        var provider = ProviderUrlHelper.DetectProvider(repository);
+
+        Assert.Equal("github", provider);
+    }
+
+    /// <summary>DetectProvider rejects blank repository input.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DetectProvider_RejectsBlankRepository(string repository)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ProviderUrlHelper.DetectProvider(repository));
+
+        Assert.Equal("repository", exception.ParamName);
+    }
+
+    /// <summary>DetectProvider reports unsupported hosts after successful host extraction.</summary>
+    [Fact]
+    public void DetectProvider_RejectsUnsupportedHost()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            ProviderUrlHelper.DetectProvider("https://gitlab.com/rian-be/ChangeTrace.git"));
+
+        Assert.Contains("gitlab.com", exception.Message);
+    }
+
+    /// <summary>DetectProvider reports an invalid repository string when no host can be extracted.</summary>
+    [Fact]
+    public void DetectProvider_RejectsInvalidRepositoryString()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ProviderUrlHelper.DetectProvider("not-a-repository"));
+
+        Assert.Equal("Unable to determine repository host.", exception.Message);
+    }
+}

--- a/Tests/GIt/Services/RepositoryExporterTests.cs
+++ b/Tests/GIt/Services/RepositoryExporterTests.cs
@@ -1,0 +1,229 @@
+using ChangeTrace.Core.Interfaces;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Options;
+using ChangeTrace.Core.Results;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Interfaces;
+using ChangeTrace.GIt.Options;
+using ChangeTrace.GIt.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Services;
+
+/// <summary>Tests repository export orchestration across reader, builder, and repository services.</summary>
+public sealed class RepositoryExporterTests
+{
+    /// <summary>ExportAsync clones remote repositories, forwards reader options, and builds a normalized timeline.</summary>
+    [Fact]
+    public async Task ExportAsync_ClonesRemoteReadsCommitsAndBuildsTimeline()
+    {
+        var commit = CreateCommitData(1_735_689_600);
+        var reader = new TestGitRepositoryReader { CommitsToReturn = [commit] };
+        var builder = new TestTimelineBuilder();
+        var exporter = CreateExporter(reader, builder, new TestTimelineRepository());
+        var options = new ExportOptions
+        {
+            IncludeFileChanges = false,
+            IncludeBranchEvents = false,
+            IncludeMergeDetection = false,
+            MaxCommits = 5,
+            StartDate = DateTimeOffset.FromUnixTimeSeconds(100),
+            EndDate = DateTimeOffset.FromUnixTimeSeconds(200)
+        };
+
+        var result = await exporter.ExportAsync("https://github.com/rian-be/ChangeTrace.git", options);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("https://github.com/rian-be/ChangeTrace.git", reader.ClonedUrl);
+        Assert.NotNull(reader.CloneDestinationPath);
+        Assert.Equal(reader.CloneDestinationPath, reader.ReadRepositoryPath);
+        Assert.Equal(false, reader.ReadOptions?.IncludeFileChanges);
+        Assert.Equal(5, reader.ReadOptions?.MaxCommits);
+        Assert.Equal(options.StartDate, reader.ReadOptions?.StartDate);
+        Assert.Equal(options.EndDate, reader.ReadOptions?.EndDate);
+        Assert.Same(reader.CommitsToReturn, builder.Commits);
+        Assert.Equal("rian-be", builder.Options?.RepositoryId?.Owner);
+        Assert.Equal("ChangeTrace", builder.Options?.RepositoryId?.Name);
+        Assert.False(builder.Options?.IncludeFileChanges);
+        Assert.False(builder.Options?.IncludeBranchEvents);
+        Assert.False(builder.Options?.IncludeMergeDetection);
+    }
+
+    /// <summary>ExportAsync returns reader failures without invoking the timeline builder.</summary>
+    [Fact]
+    public async Task ExportAsync_ReturnsFailureWhenReaderFails()
+    {
+        var reader = new TestGitRepositoryReader
+        {
+            ReadResult = Result<IReadOnlyList<CommitData>>.Failure("read failed")
+        };
+        var builder = new TestTimelineBuilder();
+        var exporter = CreateExporter(reader, builder, new TestTimelineRepository());
+
+        var result = await exporter.ExportAsync("https://github.com/rian-be/ChangeTrace.git", new ExportOptions());
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("read failed", result.Error);
+        Assert.Null(builder.Commits);
+    }
+
+    /// <summary>ExportAndSaveAsync saves the exported timeline to the requested output path.</summary>
+    [Fact]
+    public async Task ExportAndSaveAsync_SavesTimelineAfterSuccessfulExport()
+    {
+        var reader = new TestGitRepositoryReader { CommitsToReturn = [CreateCommitData(1_735_689_600)] };
+        var builder = new TestTimelineBuilder();
+        var repository = new TestTimelineRepository();
+        var exporter = CreateExporter(reader, builder, repository);
+
+        var result = await exporter.ExportAndSaveAsync(
+            "https://github.com/rian-be/ChangeTrace.git",
+            "/tmp/output.gittrace",
+            new ExportOptions());
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(builder.TimelineToReturn, repository.SavedTimeline);
+        Assert.Equal("/tmp/output.gittrace", repository.SavedPath);
+    }
+
+    /// <summary>ExportAndSaveAsync propagates repository save failures.</summary>
+    [Fact]
+    public async Task ExportAndSaveAsync_ReturnsFailureWhenSaveFails()
+    {
+        var reader = new TestGitRepositoryReader { CommitsToReturn = [CreateCommitData(1_735_689_600)] };
+        var repository = new TestTimelineRepository { SaveResult = Result.Failure("save failed") };
+        var exporter = CreateExporter(reader, new TestTimelineBuilder(), repository);
+
+        var result = await exporter.ExportAndSaveAsync(
+            "https://github.com/rian-be/ChangeTrace.git",
+            "/tmp/output.gittrace",
+            new ExportOptions());
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("save failed", result.Error);
+    }
+
+    /// <summary>Creates an exporter wired with test doubles.</summary>
+    private static RepositoryExporter CreateExporter(
+        IGitRepositoryReader reader,
+        ITimelineBuilder builder,
+        ITimelineRepository repository)
+        => new(
+            reader,
+            builder,
+            repository,
+            NullLogger<RepositoryExporter>.Instance);
+
+    /// <summary>Creates a commit fixture for repository exporter tests.</summary>
+    private static CommitData CreateCommitData(long timestamp)
+        => new(
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            ActorName.Create("rian").Value,
+            Timestamp.Create(timestamp).Value,
+            "Initial commit",
+            [],
+            [],
+            [BranchName.Create("main").Value],
+            IsMerge: false);
+
+    /// <summary>Git reader test double that records clone and read calls.</summary>
+    private sealed class TestGitRepositoryReader : IGitRepositoryReader
+    {
+        /// <summary>Commits returned by ReadCommitsAsync when ReadResult is not configured.</summary>
+        public IReadOnlyList<CommitData> CommitsToReturn { get; init; } = [];
+
+        /// <summary>Optional explicit read result.</summary>
+        public Result<IReadOnlyList<CommitData>>? ReadResult { get; init; }
+
+        /// <summary>URL passed to CloneAsync.</summary>
+        public string? ClonedUrl { get; private set; }
+
+        /// <summary>Destination path passed to CloneAsync.</summary>
+        public string? CloneDestinationPath { get; private set; }
+
+        /// <summary>Repository path passed to ReadCommitsAsync.</summary>
+        public string? ReadRepositoryPath { get; private set; }
+
+        /// <summary>Reader options passed to ReadCommitsAsync.</summary>
+        public GitReaderOptions? ReadOptions { get; private set; }
+
+        /// <summary>Records read inputs and returns configured commits or result.</summary>
+        public Task<Result<IReadOnlyList<CommitData>>> ReadCommitsAsync(
+            string repositoryPath,
+            GitReaderOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            ReadRepositoryPath = repositoryPath;
+            ReadOptions = options;
+            return Task.FromResult(ReadResult ?? Result<IReadOnlyList<CommitData>>.Success(CommitsToReturn));
+        }
+
+        /// <summary>Records clone inputs and returns success.</summary>
+        public Task<Result> CloneAsync(
+            string url,
+            string destinationPath,
+            CancellationToken cancellationToken = default)
+        {
+            ClonedUrl = url;
+            CloneDestinationPath = destinationPath;
+            return Task.FromResult(Result.Success());
+        }
+    }
+
+    /// <summary>Timeline builder test double that records commits and options.</summary>
+    private sealed class TestTimelineBuilder : ITimelineBuilder
+    {
+        /// <summary>Commits passed to Build.</summary>
+        public IReadOnlyList<CommitData>? Commits { get; private set; }
+
+        /// <summary>Options passed to Build.</summary>
+        public TimelineBuilderOptions? Options { get; private set; }
+
+        /// <summary>Timeline returned by Build.</summary>
+        public Timeline TimelineToReturn { get; } = new(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+
+        /// <summary>Records inputs and returns the configured timeline.</summary>
+        public Result<Timeline> Build(
+            IReadOnlyList<CommitData> commits,
+            TimelineBuilderOptions options)
+        {
+            Commits = commits;
+            Options = options;
+            TimelineToReturn.AddEvent(TraceEventFactory.Commit(
+                Timestamp.Create(1_735_689_600).Value,
+                ActorName.Create("rian").Value,
+                CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value));
+            return Result<Timeline>.Success(TimelineToReturn);
+        }
+    }
+
+    /// <summary>Timeline repository test double that records save calls.</summary>
+    private sealed class TestTimelineRepository : ITimelineRepository
+    {
+        /// <summary>Timeline passed to SaveAsync.</summary>
+        public Timeline? SavedTimeline { get; private set; }
+
+        /// <summary>Path passed to SaveAsync.</summary>
+        public string? SavedPath { get; private set; }
+
+        /// <summary>Result returned by SaveAsync.</summary>
+        public Result SaveResult { get; init; } = Result.Success();
+
+        /// <summary>Records save inputs and returns configured result.</summary>
+        public Task<Result> SaveAsync(
+            Timeline timeline,
+            string filePath,
+            CancellationToken cancellationToken = default)
+        {
+            SavedTimeline = timeline;
+            SavedPath = filePath;
+            return Task.FromResult(SaveResult);
+        }
+
+        /// <summary>Load is not used by repository exporter tests.</summary>
+        public Task<Result<Timeline>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
+            => Task.FromResult(Result<Timeline>.Failure("not used"));
+    }
+}

--- a/Tests/GIt/Services/TimelineRepositoryMsgPackTests.cs
+++ b/Tests/GIt/Services/TimelineRepositoryMsgPackTests.cs
@@ -1,0 +1,152 @@
+using ChangeTrace.Core.Interfaces;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Services;
+
+/// <summary>Tests timeline repository persistence behavior around serialization and file access.</summary>
+public sealed class TimelineRepositoryMsgPackTests
+{
+    /// <summary>SaveAsync ensures the gittrace extension, serializes the timeline, and saves bytes.</summary>
+    [Fact]
+    public async Task SaveAsync_EnsuresExtensionSerializesAndSavesBytes()
+    {
+        var serializer = new TestTimelineSerializer();
+        var fileManager = new TestFileManager();
+        var repository = new TimelineRepositoryMsgPack(
+            NullLogger<TimelineRepositoryMsgPack>.Instance,
+            serializer,
+            fileManager);
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        var path = Path.Combine(Path.GetTempPath(), "ChangeTrace.Tests", Ulid.NewUlid().ToString(), "timeline");
+
+        var result = await repository.SaveAsync(timeline, path);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(timeline, serializer.SerializedTimeline);
+        Assert.Equal(path + ".gittrace", fileManager.SavedPath);
+        Assert.Equal([1, 2, 3], fileManager.SavedBytes);
+        Assert.True(File.Exists(path + ".gittrace.debug.json"));
+    }
+
+    /// <summary>LoadAsync loads bytes from the requested path and deserializes them into a timeline.</summary>
+    [Fact]
+    public async Task LoadAsync_LoadsBytesAndDeserializesTimeline()
+    {
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        var serializer = new TestTimelineSerializer { TimelineToDeserialize = timeline };
+        var fileManager = new TestFileManager { BytesToLoad = [9, 8, 7] };
+        var repository = new TimelineRepositoryMsgPack(
+            NullLogger<TimelineRepositoryMsgPack>.Instance,
+            serializer,
+            fileManager);
+
+        var result = await repository.LoadAsync("/tmp/source.gittrace");
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(timeline, result.Value);
+        Assert.Equal("/tmp/source.gittrace", fileManager.LoadedPath);
+        Assert.Equal([9, 8, 7], serializer.DeserializedBytes);
+    }
+
+    /// <summary>SaveAsync wraps serializer failures in a failed Result.</summary>
+    [Fact]
+    public async Task SaveAsync_ReturnsFailureWhenSerializerThrows()
+    {
+        var serializer = new TestTimelineSerializer
+        {
+            SerializeException = new InvalidOperationException("serializer failed")
+        };
+        var repository = new TimelineRepositoryMsgPack(
+            NullLogger<TimelineRepositoryMsgPack>.Instance,
+            serializer,
+            new TestFileManager());
+
+        var result = await repository.SaveAsync(new Timeline(null), "/tmp/timeline");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("Failed to save timeline", result.Error);
+    }
+
+    /// <summary>Serializer test double with configurable serialized and deserialized values.</summary>
+    private sealed class TestTimelineSerializer : ISerializer<Timeline>
+    {
+        /// <summary>Timeline passed to SerializeAsync.</summary>
+        public Timeline? SerializedTimeline { get; private set; }
+
+        /// <summary>Bytes passed to DeserializeAsync.</summary>
+        public byte[]? DeserializedBytes { get; private set; }
+
+        /// <summary>Timeline returned by DeserializeAsync.</summary>
+        public Timeline TimelineToDeserialize { get; init; } = new(null);
+
+        /// <summary>Optional exception thrown by SerializeAsync.</summary>
+        public Exception? SerializeException { get; init; }
+
+        /// <summary>Records the timeline and returns deterministic bytes.</summary>
+        public Task<byte[]> SerializeAsync(Timeline obj, CancellationToken ct = default)
+        {
+            if (SerializeException is not null)
+                throw SerializeException;
+
+            SerializedTimeline = obj;
+            return Task.FromResult<byte[]>([1, 2, 3]);
+        }
+
+        /// <summary>Records bytes and returns the configured timeline.</summary>
+        public Task<Timeline> DeserializeAsync(byte[] data, CancellationToken ct = default)
+        {
+            DeserializedBytes = data;
+            return Task.FromResult(TimelineToDeserialize);
+        }
+    }
+
+    /// <summary>File manager test double that records load and save calls.</summary>
+    private sealed class TestFileManager : IFileManager
+    {
+        /// <summary>Path passed to SaveAsync.</summary>
+        public string? SavedPath { get; private set; }
+
+        /// <summary>Bytes passed to SaveAsync.</summary>
+        public byte[]? SavedBytes { get; private set; }
+
+        /// <summary>Path passed to LoadAsync.</summary>
+        public string? LoadedPath { get; private set; }
+
+        /// <summary>Bytes returned by LoadAsync.</summary>
+        public byte[] BytesToLoad { get; init; } = [];
+
+        /// <summary>Records bytes and creates the target directory for repository debug output.</summary>
+        public Task SaveAsync(string path, byte[] data, CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            SavedPath = path;
+            SavedBytes = data;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Records the path and returns configured bytes.</summary>
+        public Task<byte[]> LoadAsync(string path, CancellationToken cancellationToken = default)
+        {
+            LoadedPath = path;
+            return Task.FromResult(BytesToLoad);
+        }
+
+        /// <summary>Returns whether a file exists on disk.</summary>
+        public bool Exists(string path) => File.Exists(path);
+
+        /// <summary>Returns fallback text for tests that do not cover text reads.</summary>
+        public Task<string> ReadAllTextAsync(string path, string fallback = "", CancellationToken ct = default)
+            => Task.FromResult(fallback);
+
+        /// <summary>Adds an extension when the path does not already end with it.</summary>
+        public string EnsureExtension(string path, string extension)
+            => path.EndsWith(extension, StringComparison.OrdinalIgnoreCase) ? path : path + extension;
+
+        /// <summary>Returns no files for tests that do not cover file discovery.</summary>
+        public IEnumerable<string> FindFiles(string directory, string extension) => [];
+    }
+}

--- a/Tests/Player/Handlers/BoundaryHandlerTests.cs
+++ b/Tests/Player/Handlers/BoundaryHandlerTests.cs
@@ -1,0 +1,160 @@
+using ChangeTrace.Core.Events;
+using ChangeTrace.Player.Enums;
+using ChangeTrace.Player.Handlers;
+using ChangeTrace.Player.Interfaces;
+using Xunit;
+
+namespace ChangeTrace.Tests.Player.Handlers;
+
+/// <summary>Tests playback boundary handlers without running playback loop.</summary>
+public sealed class BoundaryHandlerTests
+{
+    /// <summary>OnceBoundaryHandler stops playback and does not report loop.</summary>
+    [Fact]
+    public void OnceBoundaryHandler_Handle_StopsPlayback()
+    {
+        var handler = new OnceBoundaryHandler();
+
+        var shouldStop = handler.Handle(
+            new TestEventCursor(),
+            new TestVirtualClock(),
+            out var loopFired);
+
+        Assert.True(shouldStop);
+        Assert.False(loopFired);
+    }
+
+    /// <summary>LoopBoundaryHandler resets cursor and clock before continuing playback.</summary>
+    [Fact]
+    public void LoopBoundaryHandler_Handle_ResetsCursorAndClock()
+    {
+        var cursor = new TestEventCursor();
+        var clock = new TestVirtualClock();
+        var handler = new LoopBoundaryHandler();
+
+        var shouldStop = handler.Handle(cursor, clock, out var loopFired);
+
+        Assert.False(shouldStop);
+        Assert.True(loopFired);
+        Assert.Equal(1, cursor.ResetToStartCount);
+        Assert.Equal(0, clock.SnappedPosition);
+    }
+
+    /// <summary>PingPongBoundaryHandler flips direction at each boundary hit.</summary>
+    [Fact]
+    public void PingPongBoundaryHandler_Handle_TogglesDirection()
+    {
+        var handler = new PingPongBoundaryHandler();
+
+        handler.Handle(
+            new TestEventCursor(),
+            new TestVirtualClock(),
+            out var firstLoop);
+        var firstDirection = handler.Direction;
+
+        handler.Handle(
+            new TestEventCursor(),
+            new TestVirtualClock(),
+            out var secondLoop);
+
+        Assert.True(firstLoop);
+        Assert.True(secondLoop);
+        Assert.Equal(PlaybackDirection.Backward, firstDirection);
+        Assert.Equal(PlaybackDirection.Forward, handler.Direction);
+    }
+
+    /// <summary>Event cursor test double that records reset calls.</summary>
+    private sealed class TestEventCursor : IEventCursor
+    {
+        /// <summary>Number of ResetToStart calls.</summary>
+        public int ResetToStartCount { get; private set; }
+
+        /// <summary>Current cursor index.</summary>
+        public int Index => 0;
+
+        /// <summary>Current event, unused by boundary handlers.</summary>
+        public TraceEvent? CurrentEvent => null;
+
+        /// <summary>First event, unused by boundary handlers.</summary>
+        public TraceEvent? FirstEvent => null;
+
+        /// <summary>Last event, unused by boundary handlers.</summary>
+        public TraceEvent? LastEvent => null;
+
+        /// <summary>Total event count, unused by boundary handlers.</summary>
+        public int TotalEvents => 0;
+
+        /// <summary>Start state, unused by boundary handlers.</summary>
+        public bool AtStart => true;
+
+        /// <summary>End state, unused by boundary handlers.</summary>
+        public bool AtEnd => true;
+
+        /// <summary>Returns no drained events.</summary>
+        public IReadOnlyList<TraceEvent> DrainForward(double virtualNow) => [];
+
+        /// <summary>Returns no drained events.</summary>
+        public IReadOnlyList<TraceEvent> DrainBackward(double virtualNow) => [];
+
+        /// <summary>Reports no forward step.</summary>
+        public (TraceEvent? Event, bool Moved) TryStepForward() => (null, false);
+
+        /// <summary>Reports no backward step.</summary>
+        public (TraceEvent? Event, bool Moved) TryStepBackward() => (null, false);
+
+        /// <summary>Ignores seek requests.</summary>
+        public void SeekTo(double virtualSeconds) { }
+
+        /// <summary>Records reset-to-start calls.</summary>
+        public void ResetToStart() => ResetToStartCount++;
+
+        /// <summary>Ignores reset-to-end calls.</summary>
+        public void ResetToEnd() { }
+    }
+
+    /// <summary>Virtual clock test double that records snapped position.</summary>
+    private sealed class TestVirtualClock : IVirtualClock
+    {
+        /// <summary>Position passed to SnapPosition.</summary>
+        public double? SnappedPosition { get; private set; }
+
+        /// <summary>Wall time, unused by boundary handlers.</summary>
+        public double WallNow => 0;
+
+        /// <summary>Virtual time, unused by boundary handlers.</summary>
+        public double VirtualNow => SnappedPosition ?? 0;
+
+        /// <summary>Current speed, unused by boundary handlers.</summary>
+        public double CurrentSpeed => 1;
+
+        /// <summary>Target speed, unused by boundary handlers.</summary>
+        public double TargetSpeed => 1;
+
+        /// <summary>Acceleration, unused by boundary handlers.</summary>
+        public double Acceleration { get; set; }
+
+        /// <summary>Ramping state, unused by boundary handlers.</summary>
+        public bool IsRamping => false;
+
+        /// <summary>Ignores start requests.</summary>
+        public void Start() { }
+
+        /// <summary>Ignores reset requests.</summary>
+        public void Reset() { }
+
+        /// <summary>Ignores target speed requests.</summary>
+        public void SetTargetSpeed(double target) { }
+
+        /// <summary>Ignores speed snap requests.</summary>
+        public void SnapSpeed(double speed) { }
+
+        /// <summary>Records snapped virtual position.</summary>
+        public void SnapPosition(double virtualPos) => SnappedPosition = virtualPos;
+
+        /// <summary>Ignores reanchor requests.</summary>
+        public void Reanchor() { }
+
+        /// <summary>Ignores freeze requests.</summary>
+        public void Freeze() { }
+    }
+}

--- a/Tests/Player/Playback/PlaybackTransportTests.cs
+++ b/Tests/Player/Playback/PlaybackTransportTests.cs
@@ -1,0 +1,49 @@
+using ChangeTrace.Player.Enums;
+using ChangeTrace.Player.Playback;
+using Xunit;
+
+namespace ChangeTrace.Tests.Player.Playback;
+
+/// <summary>Tests playback transport state transitions without rendering or timeline playback.</summary>
+public sealed class PlaybackTransportTests
+{
+    /// <summary>Play moves the transport to Playing and emits a state change.</summary>
+    [Fact]
+    public void Play_MovesIdleTransportToPlaying()
+    {
+        using var transport = new PlaybackTransport();
+        var states = new List<PlayerState>();
+        transport.OnStateChanged += states.Add;
+
+        var result = transport.Play();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(PlayerState.Playing, transport.State);
+        Assert.Equal([PlayerState.Playing], states);
+    }
+
+    /// <summary>Pause fails unless the transport is currently playing.</summary>
+    [Fact]
+    public void Pause_FailsWhenTransportIsNotPlaying()
+    {
+        using var transport = new PlaybackTransport();
+
+        var result = transport.Pause();
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(PlayerState.Idle, transport.State);
+    }
+
+    /// <summary>Stop returns the transport to Idle from Playing.</summary>
+    [Fact]
+    public void Stop_ReturnsPlayingTransportToIdle()
+    {
+        using var transport = new PlaybackTransport();
+        transport.Play();
+
+        var result = transport.Stop();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(PlayerState.Idle, transport.State);
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,25 @@
+# ChangeTrace Tests
+
+Regression tests live in `Tests/ChangeTrace.Tests.csproj`.
+
+## Run
+
+```bash
+dotnet test Tests/ChangeTrace.Tests.csproj
+```
+
+More command variants are listed in [COMMANDS.md](COMMANDS.md).
+
+The suite is designed to run without GPU access, OpenTK window creation, VSync,
+or full rendering loops.
+
+## Coverage
+
+- Core value objects, validation, timeline normalization, and aggregation.
+- CredentialTrace profile, workspace, auth, and temporary-filesystem persistence behavior.
+- Player state transitions and boundary handling.
+- Git DTO, provider helper, enricher, repository, and exporter behavior.
+- Non-interactive CLI profile/workspace logic.
+- CPU-side rendering state assembly and visibility rules.
+
+Persistence tests use temporary or in-memory filesystem locations.

--- a/Tests/Rendering/States/Edges/EdgeVisibilityFilterTests.cs
+++ b/Tests/Rendering/States/Edges/EdgeVisibilityFilterTests.cs
@@ -1,0 +1,46 @@
+using ChangeTrace.Rendering;
+using ChangeTrace.Rendering.Enums;
+using ChangeTrace.Rendering.Scene;
+using ChangeTrace.Rendering.Scene.Relations;
+using ChangeTrace.Rendering.States.Edges;
+using Xunit;
+
+namespace ChangeTrace.Tests.Rendering.States.Edges;
+
+/// <summary>Tests CPU-side hierarchy edge visibility rules.</summary>
+public sealed class EdgeVisibilityFilterTests
+{
+    /// <summary>ShouldInclude suppresses file hierarchy edges when a folder has too many file children.</summary>
+    [Fact]
+    public void ShouldInclude_SuppressesHeavyFileSiblingEdges()
+    {
+        var filter = new EdgeVisibilityFilter();
+        var folder = new SceneNode("src", NodeKind.Branch, new Vec2(0, 0));
+        var file = new SceneNode("src/Program.cs", NodeKind.File, new Vec2(1, 0));
+        var edge = new SceneEdge(folder.Id, file.Id, EdgeKind.Hierarchy, createdAt: 0);
+
+        var include = filter.ShouldInclude(edge, folder, file, new Dictionary<string, int>
+        {
+            [folder.Id] = 18
+        });
+
+        Assert.False(include);
+    }
+
+    /// <summary>ShouldInclude keeps folder hierarchy edges regardless of file sibling counts.</summary>
+    [Fact]
+    public void ShouldInclude_KeepsDirectoryEdges()
+    {
+        var filter = new EdgeVisibilityFilter();
+        var root = new SceneNode(SceneIds.Root, NodeKind.Root, new Vec2(0, 0));
+        var folder = new SceneNode("src", NodeKind.Branch, new Vec2(1, 0));
+        var edge = new SceneEdge(root.Id, folder.Id, EdgeKind.Hierarchy, createdAt: 0);
+
+        var include = filter.ShouldInclude(edge, root, folder, new Dictionary<string, int>
+        {
+            [root.Id] = 100
+        });
+
+        Assert.True(include);
+    }
+}

--- a/Tests/Rendering/States/Hud/LeaderboardAssemblerTests.cs
+++ b/Tests/Rendering/States/Hud/LeaderboardAssemblerTests.cs
@@ -1,0 +1,38 @@
+using ChangeTrace.Rendering.States.Hud;
+using Xunit;
+
+namespace ChangeTrace.Tests.Rendering.States.Hud;
+
+/// <summary>Tests CPU-side leaderboard state assembly.</summary>
+public sealed class LeaderboardAssemblerTests
+{
+    /// <summary>Assemble orders actors by recorded commit count and caches unchanged results.</summary>
+    [Fact]
+    public void Assemble_OrdersActorsByCommitCount()
+    {
+        var assembler = new LeaderboardAssembler();
+        assembler.RecordActorEvent("rian");
+        assembler.RecordActorEvent("alex");
+        assembler.RecordActorEvent("rian");
+
+        var leaderboard = assembler.Assemble();
+        var cached = assembler.Assemble();
+
+        Assert.Equal("rian", leaderboard[0].Actor);
+        Assert.Equal(2, leaderboard[0].EventCount);
+        Assert.Equal("alex", leaderboard[1].Actor);
+        Assert.Same(leaderboard, cached);
+    }
+
+    /// <summary>Reset clears recorded actors and cached leaderboard state.</summary>
+    [Fact]
+    public void Reset_ClearsLeaderboard()
+    {
+        var assembler = new LeaderboardAssembler();
+        assembler.RecordActorEvent("rian");
+
+        assembler.Reset();
+
+        Assert.Empty(assembler.Assemble());
+    }
+}

--- a/Tests/Rendering/States/Nodes/NodeSnapshotAssemblerTests.cs
+++ b/Tests/Rendering/States/Nodes/NodeSnapshotAssemblerTests.cs
@@ -1,0 +1,38 @@
+using ChangeTrace.Rendering;
+using ChangeTrace.Rendering.Enums;
+using ChangeTrace.Rendering.Scene;
+using ChangeTrace.Rendering.States.Nodes;
+using Xunit;
+
+namespace ChangeTrace.Tests.Rendering.States.Nodes;
+
+/// <summary>Tests CPU-side node snapshot assembly.</summary>
+public sealed class NodeSnapshotAssemblerTests
+{
+    /// <summary>Assemble assigns root, folder, and file snapshot styles without GPU access.</summary>
+    [Fact]
+    public void Assemble_BuildsSnapshotsWithExpectedParentIdsAndStyles()
+    {
+        var root = new SceneNode(SceneIds.Root, NodeKind.Root, new Vec2(0, 0));
+        var folder = new SceneNode("src", NodeKind.Branch, new Vec2(1, 0)) { IsParent = true };
+        var file = new SceneNode("src/Program.cs", NodeKind.File, new Vec2(2, 0)) { Glow = 1f };
+        var nodes = new Dictionary<string, SceneNode>
+        {
+            [root.Id] = root,
+            [folder.Id] = folder,
+            [file.Id] = file
+        };
+        var assembler = new NodeSnapshotAssembler();
+
+        var snapshots = assembler.Assemble(nodes);
+
+        var rootSnapshot = snapshots.Single(snapshot => snapshot.Id == SceneIds.Root);
+        var folderSnapshot = snapshots.Single(snapshot => snapshot.Id == "src");
+        var fileSnapshot = snapshots.Single(snapshot => snapshot.Id == "src/Program.cs");
+        Assert.Null(rootSnapshot.ParentId);
+        Assert.Equal("__root_files__", folderSnapshot.ParentId);
+        Assert.Equal("src", fileSnapshot.ParentId);
+        Assert.True(rootSnapshot.Radius > folderSnapshot.Radius);
+        Assert.True(fileSnapshot.Glow > 0);
+    }
+}

--- a/Tests/TestDoubles/InMemoryProfileStore.cs
+++ b/Tests/TestDoubles/InMemoryProfileStore.cs
@@ -1,0 +1,37 @@
+using ChangeTrace.CredentialTrace.Interfaces;
+
+namespace ChangeTrace.Tests.TestDoubles;
+
+/// <summary>Inmemory profile store test double keyed by profile id.</summary>
+internal sealed class InMemoryProfileStore<T>(params T[] profiles) : IProfileStore<T>
+    where T : class, IProfile
+{
+    private readonly Dictionary<Ulid, T> _profiles = profiles.ToDictionary(profile => profile.Id);
+
+    /// <summary>Saves or replaces profile by id.</summary>
+    public Task SaveAsync(T profile, CancellationToken ct = default)
+    {
+        _profiles[profile.Id] = profile;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Deletes profile by id when present.</summary>
+    public Task DeleteAsync(Ulid id, CancellationToken ct = default)
+    {
+        _profiles.Remove(id);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Returns the profile stored for the id, if present.</summary>
+    public Task<T?> GetAsync(Ulid id, CancellationToken ct = default)
+        => Task.FromResult(_profiles.GetValueOrDefault(id));
+
+    /// <summary>Finds profile by case insensitive name.</summary>
+    public Task<T?> GetByNameAsync(string name, CancellationToken ct = default)
+        => Task.FromResult(_profiles.Values.FirstOrDefault(profile =>
+            profile.Name.Equals(name, StringComparison.OrdinalIgnoreCase)));
+
+    /// <summary>Returns all profiles currently stored in memory.</summary>
+    public Task<IEnumerable<T>> GetAllAsync(CancellationToken ct = default)
+        => Task.FromResult<IEnumerable<T>>(_profiles.Values);
+}


### PR DESCRIPTION
## Summary

Introduce dedicated test project and CPU only regression suite covering Core, Git, CredentialTrace, CLI, Player, and Rendering behavior.

## Added

- New `ChangeTrace.Tests` test project
- xUnit, FluentAssertions, and NSubstitute test infrastructure
- Regression coverage for:
  - Core value objects, timeline normalization, aggregation, and serialization
  - Git DTOs, repositories, enrichers, exporters, and helpers
  - CredentialTrace profiles, authentication, workspaces, and persistence
  - CLI workspace/profile handlers
  - Player transport and boundary behavior
  - CPU-side rendering state assembly and visibility filtering
- Test documentation and command reference files

## Changed

- Added `InternalsVisibleTo` for `ChangeTrace.Tests`
- Added test project to the solution
- Updated validation documentation to include test execution guidance
- Excluded `Tests/**` from the main project item discovery


ChangeTrace now has dedicated regression suite that can be executed in CI and local development without requiring GPU access, OpenTK windows, rendering loops, or platform-specific graphics support.

The suite establishes baseline for validating Core, Git, CredentialTrace, CLI, Player, and Rendering behavior while supporting future refactoring and optimization work. :contentReference[oaicite:0]{index=0}

## Testing

- [x] `dotnet build`
- [x] `dotnet test Tests/ChangeTrace.Tests.csproj`
- [x] Existing functionality verified

Additional notes:

The regression suite is intentionally CPU only and focuses on domain logic, persistence, aggregation, playback state, CLI behavior, and rendering state generation rather than GPU rendering. :contentReference[oaicite:1]{index=1}

Closes #18 
---