### PR TITLE
Fix: include shader assets in output

### DIFF
--- a/ChangeTrace.csproj
+++ b/ChangeTrace.csproj
@@ -66,6 +66,11 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
 
+        <Content Include="src/Graphics/Shaders/Assets/**/*">
+            <Link>Shaders/Assets/%(RecursiveDir)%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+
         <Compile Remove="Assets/**/*.cs" />
         <Compile Remove="bin/**/*.cs" />
         <Compile Remove="obj/**/*.cs" />


### PR DESCRIPTION
## Summary
- include files from src/Graphics/Shaders/Assets in the project content items
- copy shader assets to the application output directory
- keep shader asset paths under Shaders/Assets in the output

## Verification
- dotnet build