### PR TITLE
Feat: Git CLI backend, streaming pipeline and .NET global tool packaging

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   publish:
     uses: ./.github/workflows/publish-artifacts.yml
+    with:
+      package_version: ${{ inputs.tag_name || github.ref_name }}
 
   release:
     name: Create GitHub pre-release
@@ -55,7 +57,7 @@ jobs:
       - name: Create checksums
         run: |
           cd dist
-          sha256sum ChangeTrace-*.zip > SHA256SUMS.txt
+          sha256sum ChangeTrace-*.zip ChangeTrace*.nupkg > SHA256SUMS.txt
 
       - name: Draft pre-release notes
         uses: release-drafter/release-drafter@v7
@@ -79,5 +81,6 @@ jobs:
           DIST_DIR: dist
           ASSET_PATTERNS: |
             ChangeTrace-*.zip
+            ChangeTrace*.nupkg
             SHA256SUMS.txt
         run: python3 -m scripts.releases.upload_release_assets

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -2,6 +2,11 @@ name: Publish Artifacts
 
 on:
   workflow_call:
+    inputs:
+      package_version:
+        description: "Optional tool package version, usually the release tag without the leading v."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -10,6 +15,51 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  tool-package:
+    name: Pack global tool
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore ChangeTrace.csproj
+
+      - name: Resolve package version
+        id: version
+        env:
+          PACKAGE_VERSION: ${{ inputs.package_version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          version="$PACKAGE_VERSION"
+          if [ -z "$version" ]; then
+            version="$REF_NAME"
+          fi
+          version="${version#v}"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}([-+][0-9A-Za-z.-]+)?$'; then
+            version="0.1.0"
+          fi
+          echo "package_version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Pack tool
+        run: >
+          dotnet pack ChangeTrace.csproj
+          -c Release
+          --no-restore
+          -p:PackageVersion=${{ steps.version.outputs.package_version }}
+
+      - name: Upload tool package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ChangeTrace-tool
+          path: nupkg/*.nupkg
+
   publish:
     name: Publish ${{ matrix.runtime }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 bin/
 obj/
 publish/
+nupkg/
 .obsidian/
 BenchmarkDotNet.Artifacts/

--- a/Benchmarks/GIt/Benchmarks/GitRepositoryReaderBenchmarks.cs
+++ b/Benchmarks/GIt/Benchmarks/GitRepositoryReaderBenchmarks.cs
@@ -61,4 +61,44 @@ public class GitRepositoryReaderBenchmarks
 
         return result.Value.Sum(commit => commit.FileChanges.Count);
     }
+
+    [Benchmark]
+    public async Task<int> ReadCommitsOnlyWithGitCli()
+    {
+        var result = await _reader.ReadCommitsAsync(
+            _fixture.RepositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: false,
+                MaxCommits: CommitCount,
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        return result.Value.Count;
+    }
+
+    [Benchmark]
+    public async Task<int> ReadCommitsWithFileChangesWithGitCli()
+    {
+        var result = await _reader.ReadCommitsAsync(
+            _fixture.RepositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                MaxCommits: CommitCount,
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        return result.Value.Sum(commit => commit.FileChanges.Count);
+    }
+
+    [Benchmark]
+    public async Task<int> ReadCommitsWithFileChangesWithGitCliNoRenames()
+    {
+        var result = await _reader.ReadCommitsAsync(
+            _fixture.RepositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                MaxCommits: CommitCount,
+                Backend: GitHistoryReaderBackend.GitCli,
+                DetectRenames: false));
+
+        return result.Value.Sum(commit => commit.FileChanges.Count);
+    }
 }

--- a/Benchmarks/GIt/Benchmarks/RepositoryExporterBenchmarks.cs
+++ b/Benchmarks/GIt/Benchmarks/RepositoryExporterBenchmarks.cs
@@ -87,6 +87,30 @@ public class RepositoryExporterBenchmarks
             return Task.FromResult(Result<IReadOnlyList<CommitData>>.Success(selected));
         }
 
+        public Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+            string repositoryPath,
+            GitReaderOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            IEnumerable<CommitData> selected = options.MaxCommits > 0
+                ? commits.Take(options.MaxCommits)
+                : commits;
+
+            return Task.FromResult(Result<IAsyncEnumerable<CommitData>>.Success(
+                StreamCommits(selected, cancellationToken)));
+        }
+
+        private static async IAsyncEnumerable<CommitData> StreamCommits(
+            IEnumerable<CommitData> commits,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var commit in commits)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return commit;
+            }
+        }
+
         public Task<Result> CloneAsync(
             string url,
             string destinationPath,

--- a/ChangeTrace.csproj
+++ b/ChangeTrace.csproj
@@ -6,9 +6,18 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         
-        <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(_IsPacking)' != 'true'">win-x64;linux-x64;osx-x64;linux-arm64;osx-arm64</RuntimeIdentifiers>
         <SelfContained>false</SelfContained> 
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
+
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>changetrace</ToolCommandName>
+        <PackageId>ChangeTrace</PackageId>
+        <Version>0.1.0</Version>
+        <Authors>rian-be</Authors>
+        <Description>Git repository timeline tracing and visualization CLI.</Description>
+        <PackageOutputPath>nupkg</PackageOutputPath>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
         
         <!-- Fix Git metadata errors -->
         <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
@@ -51,6 +60,8 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Include="readme.md" Pack="true" PackagePath="\" />
+
         <Content Include="Assets/**/*" Exclude="Assets/**/*.cs">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>

--- a/Docs/Development/Setup.md
+++ b/Docs/Development/Setup.md
@@ -32,6 +32,62 @@ Docs use:
 
 In a dev build, this can point to the binary under `bin/Debug/net10.0/`.
 
+## Global CLI
+
+For local development, ChangeTrace can also be installed as a .NET global tool:
+
+```bash
+task tool:install
+```
+
+After installation, run it from any directory:
+
+```bash
+changetrace --help
+```
+
+If the tool is already installed and you rebuilt the package, update it with:
+
+```bash
+task tool:update
+```
+
+Uninstall it with:
+
+```bash
+task tool:uninstall
+```
+
+Make sure the .NET tools directory is on `PATH`:
+
+```bash
+export PATH="$PATH:$HOME/.dotnet/tools"
+```
+
+## GitHub Release CLI
+
+GitHub releases publish runtime zip files and a `.nupkg` .NET tool package.
+After downloading the package from the release assets, install it from the
+download directory:
+
+```bash
+mkdir -p ~/.changetrace/tool-feed
+cp ChangeTrace.*.nupkg ~/.changetrace/tool-feed/
+dotnet tool install --global --add-source ~/.changetrace/tool-feed --ignore-failed-sources ChangeTrace
+```
+
+Then run:
+
+```bash
+changetrace --help
+```
+
+For a newer release, copy the new `.nupkg` into the same feed and update:
+
+```bash
+dotnet tool update --global --add-source ~/.changetrace/tool-feed --ignore-failed-sources ChangeTrace
+```
+
 ## Local Data
 
 ```text

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,6 +60,30 @@ tasks:
       - mkdir -p dist
       - cd {{.PUBLISH_DIR}} && zip -r ../../dist/ChangeTrace-{{.RUNTIME}}.zip .
 
+  tool:pack:
+    desc: Pack ChangeTrace as a local .NET tool
+    cmds:
+      - dotnet pack {{.PROJECT}} -c Release
+
+  tool:install:
+    desc: Install ChangeTrace globally from the local tool package
+    deps:
+      - tool:pack
+    cmds:
+      - dotnet tool install --global --add-source nupkg --ignore-failed-sources ChangeTrace
+
+  tool:update:
+    desc: Update the globally installed ChangeTrace tool from the local package
+    deps:
+      - tool:pack
+    cmds:
+      - dotnet tool update --global --add-source nupkg --ignore-failed-sources ChangeTrace
+
+  tool:uninstall:
+    desc: Uninstall the global ChangeTrace tool
+    cmds:
+      - dotnet tool uninstall --global ChangeTrace
+
   prerelease:tag:
     desc: Create and push a prerelease tag. Example TAG=v0.62.24-pre.1
     preconditions:

--- a/Tests/GIt/Services/GitRepositoryReaderGitCliTests.cs
+++ b/Tests/GIt/Services/GitRepositoryReaderGitCliTests.cs
@@ -1,0 +1,246 @@
+using System.Diagnostics;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Models;
+using ChangeTrace.GIt.Options;
+using ChangeTrace.GIt.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Services;
+
+public sealed class GitRepositoryReaderGitCliTests : IDisposable
+{
+    private readonly string _repositoryPath = Path.Combine(
+        Path.GetTempPath(),
+        "ChangeTrace.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task ReadCommitsAsync_GitCli_MatchesLibGit2SharpHistoryShape()
+    {
+        CreateRepository();
+
+        var reader = new GitRepositoryReader(NullLogger<GitRepositoryReader>.Instance);
+
+        var libGitResult = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(IncludeFileChanges: true));
+
+        var gitCliResult = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        Assert.True(libGitResult.IsSuccess, libGitResult.Error);
+        Assert.True(gitCliResult.IsSuccess, gitCliResult.Error);
+
+        var libGitCommits = libGitResult.Value;
+        var gitCliCommits = gitCliResult.Value;
+
+        Assert.Equal(libGitCommits.Count, gitCliCommits.Count);
+
+        for (var index = 0; index < libGitCommits.Count; index++)
+        {
+            var expected = libGitCommits[index];
+            var actual = gitCliCommits[index];
+
+            Assert.Equal(expected.Sha.Value, actual.Sha.Value);
+            Assert.Equal(expected.Author.Value, actual.Author.Value);
+            Assert.Equal(expected.Timestamp.UnixSeconds, actual.Timestamp.UnixSeconds);
+            Assert.Equal(expected.Message, actual.Message);
+            Assert.Equal(expected.IsMerge, actual.IsMerge);
+            Assert.Equal(
+                expected.ParentShas.Select(parent => parent.Value),
+                actual.ParentShas.Select(parent => parent.Value));
+            AssertFileChanges(expected.FileChanges, actual.FileChanges);
+        }
+    }
+
+    [Fact]
+    public async Task ReadCommitsAsync_GitCli_HonorsMaxCommitsAndDateRange()
+    {
+        CreateRepository();
+
+        var reader = new GitRepositoryReader(NullLogger<GitRepositoryReader>.Instance);
+        var result = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: false,
+                MaxCommits: 2,
+                StartDate: new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero),
+                EndDate: new DateTimeOffset(2026, 1, 3, 23, 59, 59, TimeSpan.Zero),
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        Assert.True(result.IsSuccess, result.Error);
+        Assert.Equal(2, result.Value.Count);
+        Assert.All(result.Value, commit => Assert.Empty(commit.FileChanges));
+        Assert.Equal(["Modify alpha", "Rename alpha"], result.Value.Select(commit => commit.Message));
+    }
+
+    [Fact]
+    public async Task ReadCommitsAsync_GitCli_CanSkipRenameDetection()
+    {
+        CreateRepository();
+
+        var reader = new GitRepositoryReader(NullLogger<GitRepositoryReader>.Instance);
+        var result = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                Backend: GitHistoryReaderBackend.GitCli,
+                DetectRenames: false));
+
+        Assert.True(result.IsSuccess, result.Error);
+
+        var renameCommit = Assert.Single(result.Value, commit => commit.Message == "Rename alpha");
+        Assert.Contains(renameCommit.FileChanges, change =>
+            change.Kind == FileChangeKind.Deleted && change.Path.Value == "alpha.txt");
+        Assert.Contains(renameCommit.FileChanges, change =>
+            change.Kind == FileChangeKind.Added && change.Path.Value == "src-alpha.txt");
+    }
+
+    [Fact]
+    public async Task ReadCommitsAsync_GitCli_HandlesQuotedPathNames()
+    {
+        CreateRepository();
+
+        var reader = new GitRepositoryReader(NullLogger<GitRepositoryReader>.Instance);
+        var result = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        Assert.True(result.IsSuccess, result.Error);
+
+        var commit = Assert.Single(result.Value, commit => commit.Message == "Add quoted path");
+        var change = Assert.Single(commit.FileChanges);
+        Assert.Equal(FileChangeKind.Added, change.Kind);
+        Assert.Equal($"docs/name\twith{'\n'}line.txt", change.Path.Value);
+    }
+
+    [Fact]
+    public async Task ReadCommitsAsync_DefaultBackendWithFileChanges_MatchesGitCliForQuotedPathNames()
+    {
+        CreateRepository();
+
+        var reader = new GitRepositoryReader(NullLogger<GitRepositoryReader>.Instance);
+
+        var defaultResult = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(IncludeFileChanges: true));
+
+        var gitCliResult = await reader.ReadCommitsAsync(
+            _repositoryPath,
+            new GitReaderOptions(
+                IncludeFileChanges: true,
+                Backend: GitHistoryReaderBackend.GitCli));
+
+        Assert.True(defaultResult.IsSuccess, defaultResult.Error);
+        Assert.True(gitCliResult.IsSuccess, gitCliResult.Error);
+
+        var defaultCommit = Assert.Single(defaultResult.Value, commit => commit.Message == "Add quoted path");
+        var gitCliCommit = Assert.Single(gitCliResult.Value, commit => commit.Message == "Add quoted path");
+        var defaultChange = Assert.Single(defaultCommit.FileChanges);
+        var gitCliChange = Assert.Single(gitCliCommit.FileChanges);
+
+        Assert.Equal(gitCliChange.Path.Value, defaultChange.Path.Value);
+        Assert.Equal(gitCliChange.Kind, defaultChange.Kind);
+        Assert.Equal(gitCliChange.OldPath?.Value, defaultChange.OldPath?.Value);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_repositoryPath))
+                Directory.Delete(_repositoryPath, recursive: true);
+        }
+        catch
+        {
+            // Best effort cleanup for temporary Git repositories.
+        }
+    }
+
+    private static void AssertFileChanges(
+        IReadOnlyList<ChangeTrace.Core.Enums.FileChange> expected,
+        IReadOnlyList<ChangeTrace.Core.Enums.FileChange> actual)
+    {
+        Assert.Equal(expected.Count, actual.Count);
+
+        for (var index = 0; index < expected.Count; index++)
+        {
+            Assert.Equal(expected[index].Path.Value, actual[index].Path.Value);
+            Assert.Equal(expected[index].Kind, actual[index].Kind);
+            Assert.Equal(expected[index].OldPath?.Value, actual[index].OldPath?.Value);
+        }
+    }
+
+    private void CreateRepository()
+    {
+        Directory.CreateDirectory(_repositoryPath);
+        RunGit("init");
+        RunGit("config", "user.name", "ChangeTrace Test");
+        RunGit("config", "user.email", "changetrace@example.com");
+
+        File.WriteAllText(Path.Combine(_repositoryPath, "alpha.txt"), "one");
+        Commit("Initial commit", "2026-01-01T00:00:00Z", "add", ".");
+
+        File.AppendAllText(Path.Combine(_repositoryPath, "alpha.txt"), $"{Environment.NewLine}two");
+        File.WriteAllText(Path.Combine(_repositoryPath, "beta.txt"), "beta");
+        Commit("Modify alpha", "2026-01-02T00:00:00Z", "add", ".");
+
+        RunGit("mv", "alpha.txt", "src-alpha.txt");
+        Commit("Rename alpha", "2026-01-03T00:00:00Z", "add", ".");
+
+        Directory.CreateDirectory(Path.Combine(_repositoryPath, "docs"));
+        File.WriteAllText(Path.Combine(_repositoryPath, "docs", $"name\twith{'\n'}line.txt"), "quoted");
+        Commit("Add quoted path", "2026-01-04T00:00:00Z", "add", ".");
+    }
+
+    private void Commit(string message, string timestamp, params string[] stageArguments)
+    {
+        RunGit(stageArguments);
+        RunGit(
+            new Dictionary<string, string>
+            {
+                ["GIT_AUTHOR_DATE"] = timestamp,
+                ["GIT_COMMITTER_DATE"] = timestamp
+            },
+            "commit",
+            "-m",
+            message);
+    }
+
+    private void RunGit(params string[] arguments)
+        => RunGit(null, arguments);
+
+    private void RunGit(IReadOnlyDictionary<string, string>? environment, params string[] arguments)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = _repositoryPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var pair in environment ?? new Dictionary<string, string>())
+            process.StartInfo.Environment[pair.Key] = pair.Value;
+
+        foreach (var argument in arguments)
+            process.StartInfo.ArgumentList.Add(argument);
+
+        process.Start();
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed: {output}{error}");
+    }
+}

--- a/Tests/GIt/Services/RepositoryExporterTests.cs
+++ b/Tests/GIt/Services/RepositoryExporterTests.cs
@@ -8,6 +8,7 @@ using ChangeTrace.GIt.Interfaces;
 using ChangeTrace.GIt.Options;
 using ChangeTrace.GIt.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 using Xunit;
 
 namespace ChangeTrace.Tests.GIt.Services;
@@ -43,7 +44,9 @@ public sealed class RepositoryExporterTests
         Assert.Equal(5, reader.ReadOptions?.MaxCommits);
         Assert.Equal(options.StartDate, reader.ReadOptions?.StartDate);
         Assert.Equal(options.EndDate, reader.ReadOptions?.EndDate);
-        Assert.Same(reader.CommitsToReturn, builder.Commits);
+        Assert.Equal(GitHistoryReaderBackend.LibGit2Sharp, reader.ReadOptions?.Backend);
+        Assert.False(reader.ReadOptions?.IncludeBranches);
+        Assert.Equal(reader.CommitsToReturn, builder.Commits);
         Assert.Equal("rian-be", builder.Options?.RepositoryId?.Owner);
         Assert.Equal("ChangeTrace", builder.Options?.RepositoryId?.Name);
         Assert.False(builder.Options?.IncludeFileChanges);
@@ -105,6 +108,33 @@ public sealed class RepositoryExporterTests
         Assert.Equal("save failed", result.Error);
     }
 
+    [Fact]
+    public async Task ExportAsync_LocalRepositoryWithFileChanges_PrefersGitCliBackend()
+    {
+        var repoPath = CreateLocalRepository();
+
+        try
+        {
+            var reader = new TestGitRepositoryReader { CommitsToReturn = [CreateCommitData(1_735_689_600)] };
+            var builder = new TestTimelineBuilder();
+            var exporter = CreateExporter(reader, builder, new TestTimelineRepository());
+
+            var result = await exporter.ExportAsync(repoPath, new ExportOptions
+            {
+                IncludeFileChanges = true,
+                IncludeBranchEvents = false,
+                IncludeMergeDetection = false
+            });
+
+            Assert.True(result.IsSuccess, result.Error);
+            Assert.Equal(GitHistoryReaderBackend.GitCli, reader.ReadOptions?.Backend);
+        }
+        finally
+        {
+            TryDeleteDirectory(repoPath);
+        }
+    }
+
     /// <summary>Creates an exporter wired with test doubles.</summary>
     private static RepositoryExporter CreateExporter(
         IGitRepositoryReader reader,
@@ -127,6 +157,80 @@ public sealed class RepositoryExporterTests
             [],
             [BranchName.Create("main").Value],
             IsMerge: false);
+
+    private static string CreateLocalRepository()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            "ChangeTrace.Tests",
+            Guid.NewGuid().ToString("N"));
+
+        Directory.CreateDirectory(path);
+        RunGit(path, "init");
+        RunGit(path, "config", "user.name", "ChangeTrace Test");
+        RunGit(path, "config", "user.email", "changetrace@example.com");
+        File.WriteAllText(Path.Combine(path, "alpha.txt"), "one");
+        RunGit(path, "add", ".");
+        RunGit(
+            path,
+            new Dictionary<string, string>
+            {
+                ["GIT_AUTHOR_DATE"] = "2026-01-01T00:00:00Z",
+                ["GIT_COMMITTER_DATE"] = "2026-01-01T00:00:00Z"
+            },
+            "commit",
+            "-m",
+            "Initial commit");
+
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best effort cleanup for temporary test repositories.
+        }
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+        => RunGit(workingDirectory, null, arguments);
+
+    private static void RunGit(
+        string workingDirectory,
+        IReadOnlyDictionary<string, string>? environment,
+        params string[] arguments)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var pair in environment ?? new Dictionary<string, string>())
+            process.StartInfo.Environment[pair.Key] = pair.Value;
+
+        foreach (var argument in arguments)
+            process.StartInfo.ArgumentList.Add(argument);
+
+        process.Start();
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed: {output}{error}");
+    }
 
     /// <summary>Git reader test double that records clone and read calls.</summary>
     private sealed class TestGitRepositoryReader : IGitRepositoryReader
@@ -158,6 +262,33 @@ public sealed class RepositoryExporterTests
             ReadRepositoryPath = repositoryPath;
             ReadOptions = options;
             return Task.FromResult(ReadResult ?? Result<IReadOnlyList<CommitData>>.Success(CommitsToReturn));
+        }
+
+        public Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+            string repositoryPath,
+            GitReaderOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            ReadRepositoryPath = repositoryPath;
+            ReadOptions = options;
+
+            if (ReadResult.HasValue && ReadResult.Value.IsFailure)
+                return Task.FromResult(Result<IAsyncEnumerable<CommitData>>.Failure(ReadResult.Value.Error!));
+
+            var commits = ReadResult.HasValue ? ReadResult.Value.Value : CommitsToReturn;
+            return Task.FromResult(Result<IAsyncEnumerable<CommitData>>.Success(
+                StreamCommits(commits, cancellationToken)));
+        }
+
+        private static async IAsyncEnumerable<CommitData> StreamCommits(
+            IEnumerable<CommitData> commits,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var commit in commits)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return commit;
+            }
         }
 
         /// <summary>Records clone inputs and returns success.</summary>
@@ -196,6 +327,20 @@ public sealed class RepositoryExporterTests
                 ActorName.Create("rian").Value,
                 CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value));
             return Result<Timeline>.Success(TimelineToReturn);
+        }
+
+        public async Task<Result<Timeline>> BuildAsync(
+            IAsyncEnumerable<CommitData> commits,
+            TimelineBuilderOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var list = new List<CommitData>();
+            await foreach (var commit in commits.WithCancellation(cancellationToken))
+            {
+                list.Add(commit);
+            }
+
+            return Build(list, options);
         }
     }
 

--- a/src/Cli/Commands/ExportCommand.cs
+++ b/src/Cli/Commands/ExportCommand.cs
@@ -35,18 +35,32 @@ internal sealed class ExportCommand : ICliCommand
     {
         var cmd = new Command("export", "Export repository timeline");
         
-        var repoArg = new Argument<string>("repository")  {  Description = "Local path or HTTPS URL to Git repository" };
+        var repoArg = new Argument<string?>("repository")
+        {
+            Arity = ArgumentArity.ZeroOrOne,
+            Description = "Local path or HTTPS URL to Git repository. Defaults to the current Git repository."
+        };
         var outputOpt = new Option<string?>("--output", "-o")
         {
             Description = "Explicit output .gittrace path. When omitted, export is saved under the active workspace."
         };
         var tokenOpt = new Option<string?>("--token", "-r")  { Description = "GitHub personal access token" };
         var verboseOpt = new Option<bool>("--verbose", "-v") { Description = "Enable verbose logging" };
+        var gitCliOpt = new Option<bool>("--git-cli")
+        {
+            Description = "Use Git CLI streaming backend. Recommended for larger local histories or when file-change extraction is expensive."
+        };
+        var noRenamesOpt = new Option<bool>("--no-renames")
+        {
+            Description = "Skip rename detection when using Git CLI file-change extraction. Faster, but renames are reported as delete/add."
+        };
         
         cmd.Arguments.Add(repoArg);
         cmd.Options.Add(outputOpt);
         cmd.Options.Add(tokenOpt);
         cmd.Options.Add(verboseOpt);
+        cmd.Options.Add(gitCliOpt);
+        cmd.Options.Add(noRenamesOpt);
         
         return cmd;
     }

--- a/src/Cli/Commands/ShowTimelineCommand.cs
+++ b/src/Cli/Commands/ShowTimelineCommand.cs
@@ -6,37 +6,19 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ChangeTrace.Cli.Commands;
 
-/// <summary>
-/// Represents 'show' CLI command that reads a .gittrace file and displays its content as JSON.
-/// </summary>
-/// <remarks>
-/// <list type="bullet">
-/// <item>Implements <see cref="ICliCommand"/> to define the command structure and associate a handler.</item>
-/// <item>Registers itself as a singleton via <see cref="AutoRegisterAttribute"/>.</item>
-/// <item>Defines argument for specifying the timeline file path.</item>
-/// <item>The actual execution logic is handled by <see cref="ShowTimelineCommandHandler"/>.</item>
-/// </list>
-/// </remarks>
 [AutoRegister(ServiceLifetime.Singleton)]
 internal sealed class ShowTimelineCommand : ICliCommand
 {
-    /// <summary>
-    /// Gets the handler type responsible for executing this command.
-    /// </summary>
     public Type HandlerType => typeof(ShowTimelineCommandHandler);
 
     public Type? Parent => null;
 
-    /// <summary>
-    /// Builds the <see cref="Command"/> instance representing the 'show' CLI command.
-    /// </summary>
-    /// <returns>A configured <see cref="Command"/> with arguments.</returns>
     public Command Build()
-    {
-        var cmd = new Command("show", "Show a .gittrace timeline file as JSON");
-        var fileArg = new Argument<string>("file") { Description = "Path to .gittrace file to display" };
-
-        cmd.Arguments.Add(fileArg);
-        return cmd;
-    }
+        => new("show", "Play a .gittrace timeline file")
+        {
+            new Argument<string>("file")
+            {
+                Description = "Path to .gittrace file to play"
+            }
+        };
 }

--- a/src/Cli/Handlers/ExportCommandHandler.cs
+++ b/src/Cli/Handlers/ExportCommandHandler.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Diagnostics;
 using ChangeTrace.Cli.Interfaces;
 using ChangeTrace.Configuration.Discovery;
 using ChangeTrace.CredentialTrace.Interfaces;
@@ -26,10 +27,19 @@ internal sealed class ExportCommandHandler(
     /// </summary>
     public async Task HandleAsync(ParseResult parseResult, CancellationToken ct)
     {
-        var repo = parseResult.GetValue<string>("repository")!;
+        var repoResult = ResolveRepository(parseResult.GetValue<string?>("repository"));
+        if (repoResult is { IsSuccess: false })
+        {
+            AnsiConsole.MarkupLine($"[red]Failed:[/] {Markup.Escape(repoResult.Error!)}");
+            return;
+        }
+
+        var repo = repoResult.Value!;
         var explicitOutput = parseResult.GetValue<string?>("--output");
         var token = parseResult.GetValue<string?>("--token");
         var verbose = parseResult.GetValue<bool>("--verbose");
+        var useGitCli = parseResult.GetValue<bool>("--git-cli");
+        var noRenames = parseResult.GetValue<bool>("--no-renames");
         var exportedAt = DateTimeOffset.UtcNow;
 
         var output = explicitOutput;
@@ -39,24 +49,28 @@ internal sealed class ExportCommandHandler(
         {
             if (workspace == null)
             {
-                AnsiConsole.MarkupLine(
-                    "[red]Failed:[/] no active workspace selected. Use [yellow]workspace use <org> <name>[/] or pass [yellow]--output/-o[/].");
-                return;
+                var repoName = GetRepositoryName(repo);
+                output = Path.Combine(Directory.GetCurrentDirectory(), $"{repoName}.gittrace");
             }
-
-            output = await workspaceTimelineStorage.CreateTimelinePathAsync(
-                workspace,
-                repo,
-                exportedAt,
-                Ulid.NewUlid().ToString(),
-                ct);
+            else
+            {
+                output = await workspaceTimelineStorage.CreateTimelinePathAsync(
+                    workspace,
+                    repo,
+                    exportedAt,
+                    Ulid.NewUlid().ToString(),
+                    ct);
+            }
         }
 
         if (string.IsNullOrWhiteSpace(token))
         {
-            var provider = ProviderUrlHelper.DetectProvider(repo);
-            var session = await sessionAuthStore.GetSession(provider, ct);
-            token = session?.AccessToken;
+            var provider = TryDetectProvider(repo);
+            if (provider is not null)
+            {
+                var session = await sessionAuthStore.GetSession(provider, ct);
+                token = session?.AccessToken;
+            }
         }
 
         var options = new ExportOptions
@@ -65,6 +79,10 @@ internal sealed class ExportCommandHandler(
             IncludeMergeDetection = true,
             EnrichWithPullRequests = true,
             IncludeBranchEvents = true,
+            HistoryBackend = useGitCli
+                ? GitHistoryReaderBackend.GitCli
+                : GitHistoryReaderBackend.LibGit2Sharp,
+            DetectRenames = !noRenames,
         };
 
         ProgressCallback? progress = verbose
@@ -93,5 +111,156 @@ internal sealed class ExportCommandHandler(
             await workspaceTimelineStorage.SaveMetadataAsync(output, workspace, repo, exportedAt, ct);
 
         AnsiConsole.MarkupLine($"[green]Exported successfully to[/] {Markup.Escape(output)}");
+        if (workspace == null)
+        {
+            var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), output);
+            AnsiConsole.MarkupLine($"[blue]Tip:[/] Run [yellow]changetrace show {Markup.Escape(relativePath)}[/] to visualize the timeline.");
+        }
+    }
+
+    private static string? TryDetectProvider(string repository)
+    {
+        try
+        {
+            return ProviderUrlHelper.DetectProvider(repository);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static RepositoryResolution ResolveRepository(string? repository)
+    {
+        if (!string.IsNullOrWhiteSpace(repository) && IsRemoteRepository(repository))
+            return RepositoryResolution.Success(repository);
+
+        var startPath = string.IsNullOrWhiteSpace(repository)
+            ? Directory.GetCurrentDirectory()
+            : Path.GetFullPath(repository);
+
+        if (File.Exists(startPath))
+            startPath = Path.GetDirectoryName(startPath)!;
+
+        if (!Directory.Exists(startPath))
+            return RepositoryResolution.Failure($"Directory not found: {startPath}");
+
+        var gitRoot = FindGitRoot(startPath);
+        return gitRoot is null
+            ? RepositoryResolution.Failure(
+                $"No Git repository found from '{startPath}'. This command needs a real Git checkout with a .git directory or gitfile.")
+            : RepositoryResolution.Success(gitRoot);
+    }
+
+    private static string? FindGitRoot(string startPath)
+    {
+        return FindGitRootWithGit(startPath) ?? FindGitRootByWalkingParents(startPath);
+    }
+
+    private static string? FindGitRootWithGit(string startPath)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.StartInfo.ArgumentList.Add("-C");
+            process.StartInfo.ArgumentList.Add(startPath);
+            process.StartInfo.ArgumentList.Add("rev-parse");
+            process.StartInfo.ArgumentList.Add("--show-toplevel");
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+                return null;
+
+            var root = output.Trim();
+            return Directory.Exists(root) ? root : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? FindGitRootByWalkingParents(string startPath)
+    {
+        var current = new DirectoryInfo(startPath);
+        while (current is not null)
+        {
+            var dotGitPath = Path.Combine(current.FullName, ".git");
+            if (Directory.Exists(dotGitPath) || File.Exists(dotGitPath))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static bool IsRemoteRepository(string repository)
+    {
+        if (Uri.TryCreate(repository, UriKind.Absolute, out var uri))
+            return uri.Scheme is "http" or "https" or "ssh" or "git";
+
+        var atIndex = repository.IndexOf('@');
+        var colonIndex = repository.IndexOf(':');
+        return atIndex > 0 && colonIndex > atIndex;
+    }
+
+    private static string GetRepositoryName(string repository)
+    {
+        if (IsRemoteRepository(repository))
+        {
+            try
+            {
+                var url = repository.Replace("git@github.com:", "https://github.com/");
+                if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                {
+                    var segments = uri.AbsolutePath
+                        .Trim('/')
+                        .Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    if (segments.Length >= 2)
+                    {
+                        var name = segments[1];
+                        if (name.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                            name = name[..^4];
+                        return name;
+                    }
+                }
+            }
+            catch
+            {
+                // Fallback
+            }
+        }
+
+        var repoDir = repository.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar);
+
+        var dirName = Path.GetFileName(repoDir);
+
+        if (dirName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            dirName = dirName[..^4];
+
+        return string.IsNullOrWhiteSpace(dirName) ? "repository" : dirName;
+    }
+
+    private readonly record struct RepositoryResolution(bool IsSuccess, string? Value, string? Error)
+    {
+        public static RepositoryResolution Success(string value) => new(true, value, null);
+        public static RepositoryResolution Failure(string error) => new(false, null, error);
     }
 }

--- a/src/Cli/Handlers/ShowTimelineCommandHandler.cs
+++ b/src/Cli/Handlers/ShowTimelineCommandHandler.cs
@@ -1,166 +1,49 @@
 using System.CommandLine;
-using System.Text.Json;
 using ChangeTrace.Cli.Interfaces;
 using ChangeTrace.Configuration.Discovery;
 using ChangeTrace.Core.Diagnostics;
 using ChangeTrace.Core.Interfaces;
-using ChangeTrace.Core.Specifications.Queries;
-using ChangeTrace.Core.Specifications.Queries.Commits;
 using ChangeTrace.Core.Timelines;
 using ChangeTrace.Graphics.Window;
 using ChangeTrace.Player.Factory;
 using ChangeTrace.Rendering.Factory;
 using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
 
 namespace ChangeTrace.Cli.Handlers;
 
 /// <summary>
-/// CLI handler to read .gittrace MessagePack file and display its content as JSON.
-/// TEMP
+/// Loads and plays a .gittrace timeline file.
 /// </summary>
 [AutoRegister(ServiceLifetime.Transient, typeof(ShowTimelineCommandHandler))]
 internal sealed class ShowTimelineCommandHandler(
     ISerializer<Timeline> serializer,
     ITimelinePlayerFactory playerFactory,
     IRenderSystemFactory renderFactory,
-    IDiagnosticsProvider diagnostics): ICliHandler
+    IDiagnosticsProvider diagnostics) : ICliHandler
 {
+    /// <summary>
+    /// Reads a timeline file and opens the player window.
+    /// </summary>
     public async Task HandleAsync(ParseResult parseResult, CancellationToken ct)
     {
         var filePath = parseResult.GetValue<string>("file")!;
+
         if (!File.Exists(filePath))
         {
-            Console.WriteLine($"[red]File not found: {filePath}[/]");
+            AnsiConsole.MarkupLine($"[red]File not found:[/] {Markup.Escape(filePath)}");
             return;
         }
 
-        try
-        {
-            var data = File.ReadAllBytes(filePath);
-            var timeline = await serializer.DeserializeAsync(data, ct);
+        AnsiConsole.MarkupLine($"[green]Playing[/] {Markup.Escape(filePath)}");
 
-            //timeline.Normalize();
+        var data = await File.ReadAllBytesAsync(filePath, ct);
+        var timeline = await serializer.DeserializeAsync(data, ct);
+        var player = playerFactory.Create(timeline, initialSpeed: 1.5, acceleration: 2.5);
 
-            var player = playerFactory.Create(
-                timeline,
-                initialSpeed: 1.5,
-                acceleration: 2.5);
-
-            var random = new Random();
-            var eventsSample = timeline.Events
-               // .OrderBy(_ => random.Next())
-               .Take(20)
-               .Select(evt => new
-               {
-                   Timestamp = evt.Core.Timestamp.UnixSeconds,
-                   Actor = evt.Core.Actor?.Value,
-                   Branch = evt.Branch?.Name?.Value,
-                   CommitSha = evt.Commit?.Sha.Value,
-                   Target = evt.Target,
-                   Metadata = evt.Metadata?.ToString()
-               })
-               .ToList();
-
-            var debugObject = new
-            {
-                Repository = timeline.RepositoryId != null
-                    ? new
-                    {
-                        timeline.RepositoryId.Owner,
-                        timeline.RepositoryId.Name
-                    }
-                    : null,
-                //timeline.IsNormalized,
-                Events = eventsSample
-            };
-
-            Console.WriteLine(
-                JsonSerializer.Serialize(
-                    debugObject,
-                    new JsonSerializerOptions
-                    {
-                        WriteIndented = true
-                    }
-                )
-            );
-
-      /*
-            var actorResult = ActorName.Create("Bryan Chen");
-            if (!actorResult.IsSuccess)
-            {
-                Console.WriteLine($"Nieprawidłowa nazwa aktora: {actorResult.Error}");
-                return Task.CompletedTask;
-            }
-            var actorc = actorResult.Value;
-            Console.WriteLine($"[red] actorc: {actorc.ToString()}[/]");
-            var spec = CommitQueries.EnrichedMerges()
-                .And(CommitQueries.ByAuthor(actorc));
-
-            var filteredEvents = timeline.Events
-                .Where(e => spec.IsSatisfiedBy(e))
-                .ToList();
-
-            var grouped = filteredEvents
-                .GroupBy(e => e.CommitSha)
-                .Select(g => new { CommitSha = g.Key, Count = g.Count() })
-                .ToList();
-
-            foreach (var g in grouped)
-            {
-                Console.WriteLine($"{g.CommitSha}: {g.Count} razy");
-            }
-
-            */
-           // var spec2 = OwnershipQueries.DirectoryOwners("src/Engine");
-            var spec2 = OwnershipQueries.DirectoryOwners("extensions/csharp/snippets/");
-            var authorsInDir = timeline.Events
-                .Where(e => spec2.IsSatisfiedBy(e))
-                .Select(e => e.Core.Actor?.Value)
-                .Where(a => a != null)
-                .Distinct()
-                .ToList();
-
-            Console.WriteLine($"Autorzy zmian w katalogu extensions/csharp/snippets/: {string.Join(", ", authorsInDir)}");
-
-            var parentSpec = CommitRelationshipQueries.Parent("0a2f0cbc5c7ebc4573ba93c7b4c007efb1110856");
-            var childSpec  = CommitRelationshipQueries.Children("0a2f0cbc5c7ebc4573ba93c7b4c007efb1110856");
-
-            var parentEvent = timeline.Events.FirstOrDefault(e => parentSpec.IsSatisfiedBy(e));
-            var childEvents = timeline.Events.Where(e => childSpec.IsSatisfiedBy(e)).ToList();
-
-            var hierarchy = new
-            {
-                Commit = parentEvent.Commit != null ? new
-                {
-                    Timestamp = parentEvent.Core.Timestamp.UnixSeconds,
-                    Actor = parentEvent.Core.Actor?.Value,
-                    CommitSha = parentEvent.Commit?.Sha.Value,
-                    Target = parentEvent.Target,
-                    Metadata = parentEvent.Metadata?.ToString()
-                } : null,
-
-                Files = childEvents.Select(e => new
-                {
-                    Timestamp = e.Core.Timestamp.UnixSeconds,
-                    Actor = e.Core.Actor?.Value,
-                    CommitSha = e.Commit?.Sha.Value,
-                    Target = e.Target,
-                    FilePath = e.Metadata?.FilePath,
-                    Metadata = e.Metadata?.ToString()
-                }).ToList()
-            };
-
-           // Console.WriteLine(JsonSerializer.Serialize(hierarchy, new JsonSerializerOptions{ WriteIndented = true }));
-
-            using var debugWindow = new DebugWindow(diagnostics);
-            using var window = new PlayerWindow(timeline, playerFactory, renderFactory, diagnostics);
-            window.SetDebugWindow(debugWindow);
-            window.Run();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[red]Failed to read or deserialize file: {ex.Message}[/]");
-            return;
-        }
+        using var debugWindow = new DebugWindow(diagnostics);
+        using var window = new PlayerWindow(timeline, playerFactory, renderFactory, diagnostics);
+        window.SetDebugWindow(debugWindow);
+        window.Run();
     }
 }

--- a/src/Core/Services/TimelineBuilder.cs
+++ b/src/Core/Services/TimelineBuilder.cs
@@ -42,19 +42,7 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
 
             foreach (var commit in commits)
             {
-                AddCommitEvent(timeline, commit);
-                if (options.IncludeFileChanges)
-                {
-                    AddFileChangeEvents(timeline, commit);
-                }
-                if (options.IncludeBranchEvents)
-                {
-                    AddBranchEvents(timeline, commit, branchTracker);
-                }
-                if (options.IncludeMergeDetection && commit.IsMerge)
-                {
-                    AddMergeEvent(timeline, commit);
-                }
+                AddCommitToTimeline(timeline, commit, options, branchTracker);
             }
             
             return Result<Timeline>.Success(timeline);
@@ -63,6 +51,60 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
         {
             logger.LogError(ex, "Failed to build timeline");
             return Result<Timeline>.Failure("Failed to build timeline", ex);
+        }
+    }
+
+    public async Task<Result<Timeline>> BuildAsync(
+        IAsyncEnumerable<CommitData> commits,
+        TimelineBuilderOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            logger.LogInformation("Building timeline from commit stream");
+
+            var timeline = new Timeline(options.RepositoryId);
+            var branchTracker = new BranchTracker();
+            var count = 0;
+
+            await foreach (var commit in commits.WithCancellation(cancellationToken))
+            {
+                AddCommitToTimeline(timeline, commit, options, branchTracker);
+                count++;
+                if (count % 50000 == 0)
+                {
+                    logger.LogInformation("Processed {Count} commits...", count);
+                }
+            }
+
+            logger.LogInformation("Built timeline from {Count} streamed commits", count);
+            return Result<Timeline>.Success(timeline);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to build timeline from commit stream");
+            return Result<Timeline>.Failure("Failed to build timeline", ex);
+        }
+    }
+
+    private static void AddCommitToTimeline(
+        Timeline timeline,
+        CommitData commit,
+        TimelineBuilderOptions options,
+        BranchTracker branchTracker)
+    {
+        AddCommitEvent(timeline, commit);
+        if (options.IncludeFileChanges)
+        {
+            AddFileChangeEvents(timeline, commit);
+        }
+        if (options.IncludeBranchEvents)
+        {
+            AddBranchEvents(timeline, commit, branchTracker);
+        }
+        if (options.IncludeMergeDetection && commit.IsMerge)
+        {
+            AddMergeEvent(timeline, commit);
         }
     }
     

--- a/src/CredentialTrace/Services/FileProfileStore.cs
+++ b/src/CredentialTrace/Services/FileProfileStore.cs
@@ -13,7 +13,7 @@ namespace ChangeTrace.CredentialTrace.Services;
 /// <typeparam name="TProfile">Type of profile, must implement <see cref="IProfile"/>.</typeparam>
 /// <remarks>
 /// <list type="bullet">
-/// <item>Persists profiles as JSON files under AppContext base directory.</item>
+/// <item>Persists profiles as JSON files under the user's ChangeTrace data directory.</item>
 /// <item>Caches loaded profiles in memory for fast access.</item>
 /// <item>Supports saving, deleting, and querying profiles by ID or name.</item>
 /// <item>Registered as singleton via <see cref="AutoRegisterAttribute"/>.</item>
@@ -32,7 +32,7 @@ internal sealed class FileProfileStore<TProfile> : IProfileStore<TProfile>
     /// </summary>
     public FileProfileStore()
     {
-        _dataDir = Path.Combine(AppContext.BaseDirectory, "profiles", typeof(TProfile).Name);
+        _dataDir = Path.Combine(GetUserDataDirectory(), "profiles", typeof(TProfile).Name);
         Directory.CreateDirectory(_dataDir);
 
         _jsonOptions = new JsonSerializerOptions
@@ -118,4 +118,9 @@ internal sealed class FileProfileStore<TProfile> : IProfileStore<TProfile>
     /// <inheritdoc/>
     public Task<IEnumerable<TProfile>> GetAllAsync(CancellationToken ct = default)
         => Task.FromResult<IEnumerable<TProfile>>(_cache.Values);
+
+    private static string GetUserDataDirectory()
+        => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".changetrace");
 }

--- a/src/CredentialTrace/Services/WorkspaceTimelineStorage.cs
+++ b/src/CredentialTrace/Services/WorkspaceTimelineStorage.cs
@@ -27,10 +27,10 @@ internal sealed class WorkspaceTimelineStorage : IWorkspaceTimelineStorage
     private readonly IProfileStore<OrganizationProfile>? _organizationStore;
 
     /// <summary>
-    /// Creates torage service rooted at the application directory.
+    /// Creates storage service rooted at the user's ChangeTrace data directory.
     /// </summary>
     public WorkspaceTimelineStorage(IProfileStore<OrganizationProfile> organizationStore)
-        : this(AppContext.BaseDirectory, organizationStore)
+        : this(GetUserDataDirectory(), organizationStore)
     {
     }
 
@@ -289,6 +289,11 @@ internal sealed class WorkspaceTimelineStorage : IWorkspaceTimelineStorage
             ? "unknown"
             : slug;
     }
+
+    private static string GetUserDataDirectory()
+        => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".changetrace");
 
     /// <summary>
     /// Represents repository owner and name.

--- a/src/GIt/History/Backends/GitCliHistoryReader.cs
+++ b/src/GIt/History/Backends/GitCliHistoryReader.cs
@@ -1,0 +1,115 @@
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+using ChangeTrace.GIt.History.GitCli;
+using ChangeTrace.GIt.Interfaces;
+using ChangeTrace.GIt.Options;
+using Microsoft.Extensions.Logging;
+
+namespace ChangeTrace.GIt.History.Backends;
+
+/// <summary>
+/// Git CLI based commit history reader.
+/// Validates repository access and streams parsed git log output.
+/// </summary>
+internal sealed class GitCliHistoryReader(ILogger logger) : ICommitHistoryReaderBackend
+{
+    /// <summary>
+    /// Backend type used by this reader.
+    /// </summary>
+    public GitHistoryReaderBackend Backend => GitHistoryReaderBackend.GitCli;
+
+    /// <summary>
+    /// Reads commit history from a Git repository.
+    /// </summary>
+    public async Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var validation = await GitCliProcessRunner.RunAsync(
+                repositoryPath,
+                ["rev-parse", "--git-dir"],
+                cancellationToken);
+
+            if (validation.ExitCode != 0)
+                return Result<IAsyncEnumerable<CommitData>>.Failure("Invalid Git repository");
+
+            var branches = options.IncludeBranches
+                ? await GetCurrentBranchAsync(repositoryPath, cancellationToken)
+                : [];
+            var arguments = BuildGitLogArguments(options);
+
+            return Result<IAsyncEnumerable<CommitData>>.Success(
+                GitCliLogParser.ReadAsync(
+                    repositoryPath,
+                    arguments,
+                    options.IncludeFileChanges,
+                    branches,
+                    cancellationToken));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to read repository with Git CLI");
+            return Result<IAsyncEnumerable<CommitData>>.Failure("Failed to read repository with Git CLI", ex);
+        }
+    }
+
+    /// <summary>
+    /// Builds git log arguments from reader options.
+    /// </summary>
+    private static List<string> BuildGitLogArguments(GitReaderOptions options)
+    {
+        var arguments = new List<string>
+        {
+            "log",
+            "--topo-order",
+            "--reverse",
+            "--date-order",
+            "--diff-merges=first-parent",
+            $"--pretty=format:{GitCliLogParser.RecordSeparator}%H{GitCliLogParser.UnitSeparator}%an{GitCliLogParser.UnitSeparator}%at{GitCliLogParser.UnitSeparator}%P{GitCliLogParser.UnitSeparator}%s"
+        };
+
+        if (options.IncludeFileChanges)
+        {
+            arguments.Add("--name-status");
+            arguments.Add("-z");
+            arguments.Add(options.DetectRenames ? "-M" : "--no-renames");
+        }
+
+        if (options.MaxCommits > 0)
+            arguments.Add($"--max-count={options.MaxCommits}");
+
+        if (options.StartDate.HasValue)
+            arguments.Add($"--since=@{options.StartDate.Value.ToUnixTimeSeconds()}");
+
+        if (options.EndDate.HasValue)
+            arguments.Add($"--until=@{options.EndDate.Value.ToUnixTimeSeconds()}");
+
+        return arguments;
+    }
+
+    /// <summary>
+    /// Reads the currently checked out branch.
+    /// </summary>
+    private static async Task<IReadOnlyList<BranchName>> GetCurrentBranchAsync(
+        string repositoryPath,
+        CancellationToken cancellationToken)
+    {
+        var result = await GitCliProcessRunner.RunAsync(
+            repositoryPath,
+            ["branch", "--show-current"],
+            cancellationToken);
+
+        if (result.ExitCode != 0)
+            return [];
+
+        var branchName = result.Output.Trim();
+        if (string.IsNullOrWhiteSpace(branchName))
+            return [];
+
+        var branchResult = BranchName.Create(branchName);
+        return branchResult.IsSuccess ? [branchResult.Value] : [];
+    }
+}

--- a/src/GIt/History/Backends/LibGit2SharpHistoryReader.cs
+++ b/src/GIt/History/Backends/LibGit2SharpHistoryReader.cs
@@ -1,0 +1,400 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+using ChangeTrace.GIt.Interfaces;
+using ChangeTrace.GIt.Options;
+using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
+
+namespace ChangeTrace.GIt.History.Backends;
+
+/// <summary>
+/// LibGit2Sharp based commit history reader.
+/// Loads commit metadata, branches and file changes.
+/// </summary>
+internal sealed class LibGit2SharpHistoryReader(ILogger logger)
+    : ICommitHistoryReaderBackend
+{
+    /// <summary>
+    /// Backend type used by this reader.
+    /// </summary>
+    public GitHistoryReaderBackend Backend => GitHistoryReaderBackend.LibGit2Sharp;
+
+    /// <summary>
+    /// Reads commit history from a Git repository.
+    /// </summary>
+    public async Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken)
+    {
+        var result = await ReadCommitsAsync(repositoryPath, options, cancellationToken);
+
+        return result.IsFailure
+            ? Result<IAsyncEnumerable<CommitData>>.Failure(result.Error!)
+            : Result<IAsyncEnumerable<CommitData>>.Success(StreamList(result.Value, cancellationToken));
+    }
+
+    /// <summary>
+    /// Reads and maps commits into domain models.
+    /// </summary>
+    private async Task<Result<IReadOnlyList<CommitData>>> ReadCommitsAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken)
+    {
+        return await Task.Run(async () =>
+        {
+            if (!Repository.IsValid(repositoryPath))
+                return Result<IReadOnlyList<CommitData>>.Failure("Invalid Git repository");
+
+            try
+            {
+                using var repo = new Repository(repositoryPath);
+
+                var commitToBranches = options.IncludeBranches && RequiresBranchMap(repo)
+                    ? BuildCommitToBranchMap(repo)
+                    : null;
+
+                var filter = new CommitFilter
+                {
+                    SortBy = CommitSortStrategies.Time | CommitSortStrategies.Topological
+                };
+
+                var commits = repo.Commits
+                    .QueryBy(filter)
+                    .Where(commit => IsCommitInRange(commit, options))
+                    .Take(options.MaxCommits > 0 ? options.MaxCommits : int.MaxValue)
+                    .ToList();
+
+                if (!options.IncludeFileChanges)
+                {
+                    var commitResults = new List<CommitData>(commits.Count);
+                    foreach (var commit in commits)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var result = MapCommit(
+                            repo,
+                            commit,
+                            includeFileChanges: false,
+                            options.IncludeBranches,
+                            commitToBranches);
+
+                        if (result.IsSuccess)
+                            commitResults.Add(result.Value);
+                    }
+
+                    var orderedCommits = commitResults
+                        .OrderBy(commit => commit.Timestamp.UnixSeconds)
+                        .ToList()
+                        .AsReadOnly();
+
+                    logger.LogInformation("Read {Count} commits", orderedCommits.Count);
+
+                    return Result<IReadOnlyList<CommitData>>.Success(orderedCommits);
+                }
+
+                var concurrentResults = new ConcurrentBag<CommitData>();
+                var semaphore = new SemaphoreSlim(4);
+
+                var tasks = commits
+                    .Select(async commit =>
+                    {
+                        await semaphore.WaitAsync(cancellationToken);
+
+                        try
+                        {
+                            if (cancellationToken.IsCancellationRequested)
+                                return;
+
+                            var result = MapCommit(
+                                repo,
+                                commit,
+                                includeFileChanges: true,
+                                options.IncludeBranches,
+                                commitToBranches);
+
+                            if (result.IsSuccess)
+                                concurrentResults.Add(result.Value);
+                        }
+                        finally
+                        {
+                            semaphore.Release();
+                        }
+                    })
+                    .ToArray();
+
+                await Task.WhenAll(tasks);
+
+                var orderedConcurrentCommits = concurrentResults
+                    .OrderBy(commit => commit.Timestamp.UnixSeconds)
+                    .ToList()
+                    .AsReadOnly();
+
+                logger.LogInformation("Read {Count} commits", orderedConcurrentCommits.Count);
+
+                return Result<IReadOnlyList<CommitData>>.Success(orderedConcurrentCommits);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to read repository");
+
+                return Result<IReadOnlyList<CommitData>>.Failure("Failed to read repository", ex);
+            }
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Streams commits from an in-memory collection.
+    /// </summary>
+    private static async IAsyncEnumerable<CommitData> StreamList(
+        IEnumerable<CommitData> commits,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var commit in commits)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return commit;
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a commit matches date filters.
+    /// </summary>
+    private static bool IsCommitInRange(
+        Commit commit,
+        GitReaderOptions options)
+    {
+        return (!options.StartDate.HasValue || commit.Author.When >= options.StartDate.Value)
+               && (!options.EndDate.HasValue || commit.Author.When <= options.EndDate.Value);
+    }
+
+    /// <summary>
+    /// Builds a commit-to-branch lookup table.
+    /// </summary>
+    private Dictionary<string, List<string>> BuildCommitToBranchMap(
+        Repository repo)
+    {
+        var map = new Dictionary<string, List<string>>();
+
+        const int maxWalk = 1000;
+
+        foreach (var branch in repo.Branches.Where(branch => !branch.IsRemote && branch.Tip != null))
+        {
+            var branchName = branch.FriendlyName;
+
+            AddToMap(map, branch.Tip.Sha, branchName);
+
+            foreach (var (commit, index) in repo.Commits
+                         .QueryBy(new CommitFilter
+                         {
+                             IncludeReachableFrom = branch.Tip,
+                             SortBy = CommitSortStrategies.Topological
+                         })
+                         .Select((commit, index) => (commit, index)))
+            {
+                AddToMap(map, commit.Sha, branchName);
+
+                if (index + 1 >= maxWalk)
+                    break;
+            }
+        }
+
+        logger.LogDebug("Built branch map with {Count} commits", map.Count);
+
+        return map;
+    }
+
+    /// <summary>
+    /// Determines whether precise branch attribution requires a precomputed branch map.
+    /// </summary>
+    private static bool RequiresBranchMap(Repository repo)
+        => repo.Branches.Count(branch => !branch.IsRemote && branch.Tip != null) > 1;
+
+    /// <summary>
+    /// Adds a branch entry to the lookup table.
+    /// </summary>
+    private static void AddToMap(
+        Dictionary<string, List<string>> map,
+        string sha,
+        string branchName)
+        => (map.TryGetValue(sha, out var list) ? list : map[sha] = []).Add(branchName);
+
+    /// <summary>
+    /// Converts a LibGit2Sharp commit into a domain model.
+    /// </summary>
+    private Result<CommitData> MapCommit(
+        Repository repo,
+        Commit commit,
+        bool includeFileChanges,
+        bool includeBranches,
+        Dictionary<string, List<string>>? commitToBranches)
+    {
+        try
+        {
+            var basicsResult = MapCommitBasics(commit);
+            if (basicsResult.IsFailure)
+                return Result<CommitData>.Failure(basicsResult.Error!);
+
+            var (sha, author, ts, parentShas) = basicsResult.Value;
+            var fileChanges = includeFileChanges ? GetFileChanges(repo, commit) : [];
+            var branches = includeBranches
+                ? GetBranches(commit, repo, commitToBranches)
+                : [];
+
+            if (!branches.Any())
+                logger.LogTrace("No branches found for commit {Sha}", commit.Sha[..8]);
+
+            var commitData = new CommitData(
+                Sha: sha,
+                Author: author,
+                Timestamp: ts,
+                Message: commit.MessageShort,
+                ParentShas: parentShas,
+                FileChanges: fileChanges,
+                Branches: branches,
+                IsMerge: commit.Parents.Count() > 1);
+
+            return Result<CommitData>.Success(commitData);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to map commit {Sha}", commit.Sha[..8]);
+
+            return Result<CommitData>.Failure($"Failed to map commit {commit.Sha[..8]}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts validated commit metadata.
+    /// </summary>
+    private static Result<(
+        CommitSha sha,
+        ActorName author,
+        Timestamp ts,
+        List<CommitSha> parents)> MapCommitBasics(
+        Commit commit)
+    {
+        var shaResult = CommitSha.Create(commit.Sha);
+        if (shaResult.IsFailure)
+            return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(shaResult.Error!);
+
+        var authorResult = ActorName.Create(commit.Author.Name);
+        if (authorResult.IsFailure)
+            return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(authorResult.Error!);
+
+        var timestampResult = Timestamp.Create(commit.Author.When.ToUnixTimeSeconds());
+        if (timestampResult.IsFailure)
+            return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(timestampResult.Error!);
+
+        var parentShas = commit.Parents
+            .Select(parent => CommitSha.Create(parent.Sha))
+            .Where(result => result.IsSuccess)
+            .Select(result => result.Value)
+            .ToList();
+
+        return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Success(
+            (shaResult.Value, authorResult.Value, timestampResult.Value, parentShas));
+    }
+
+    /// <summary>
+    /// Resolves branch names associated with a commit.
+    /// </summary>
+    private List<BranchName> GetBranches(
+        Commit commit,
+        Repository repo,
+        Dictionary<string, List<string>>? commitToBranches)
+    {
+        if (commitToBranches != null
+            && commitToBranches.TryGetValue(commit.Sha, out var branchNames))
+        {
+            return branchNames
+                .Select(BranchName.Create)
+                .Where(result => result.IsSuccess)
+                .Select(result => result.Value)
+                .ToList();
+        }
+
+        try
+        {
+            var head = repo.Head;
+
+            if (head != null && !head.IsRemote)
+            {
+                var branchResult = BranchName.Create(head.FriendlyName);
+                if (branchResult.IsSuccess)
+                    return [branchResult.Value];
+            }
+        }
+        catch
+        {
+            // Branch metadata is best-effort.
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Extracts file changes for a commit diff.
+    /// </summary>
+    private IReadOnlyList<FileChange> GetFileChanges(
+        Repository repo,
+        Commit commit)
+    {
+        try
+        {
+            var parent = commit.Parents.FirstOrDefault();
+            if (parent == null)
+                return [];
+
+            var changes = repo.Diff.Compare<TreeChanges>(parent.Tree, commit.Tree);
+            var fileChanges = new List<FileChange>(changes.Count);
+
+            foreach (var change in changes)
+            {
+                var pathResult = FilePath.Create(change.Path);
+                if (pathResult.IsFailure)
+                    continue;
+
+                FilePath? oldPath = null;
+
+                if (change is { Status: ChangeKind.Renamed, OldPath: not null })
+                {
+                    var oldPathResult = FilePath.Create(change.OldPath);
+                    if (oldPathResult.IsSuccess)
+                        oldPath = oldPathResult.Value;
+                }
+
+                fileChanges.Add(new FileChange(
+                    Path: pathResult.Value,
+                    Kind: MapChangeKind(change.Status),
+                    OldPath: oldPath));
+            }
+
+            return fileChanges.AsReadOnly();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to get file changes for {Sha}", commit.Sha[..8]);
+
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Converts LibGit2Sharp change types into domain change types.
+    /// </summary>
+    private static FileChangeKind MapChangeKind(
+        ChangeKind kind) =>
+        kind switch
+        {
+            ChangeKind.Added => FileChangeKind.Added,
+            ChangeKind.Modified => FileChangeKind.Modified,
+            ChangeKind.Deleted => FileChangeKind.Deleted,
+            ChangeKind.Renamed => FileChangeKind.Renamed,
+            _ => FileChangeKind.Modified
+        };
+}

--- a/src/GIt/History/GitCli/GitCliLogParser.cs
+++ b/src/GIt/History/GitCli/GitCliLogParser.cs
@@ -1,0 +1,389 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+
+namespace ChangeTrace.GIt.History.GitCli;
+
+/// <summary>
+/// Parses Git CLI log output into commit domain models.
+/// Supports metadata-only and name-status history streams.
+/// </summary>
+internal static class GitCliLogParser
+{
+    /// <summary>
+    /// Record separator used by git log output.
+    /// </summary>
+    public const char RecordSeparator = '\x1e';
+
+    /// <summary>
+    /// Unit separator used by git log output.
+    /// </summary>
+    public const char UnitSeparator = '\x1f';
+
+    /// <summary>
+    /// Reads commit data from git log output.
+    /// </summary>
+    public static async IAsyncEnumerable<CommitData> ReadAsync(
+        string repositoryPath,
+        IReadOnlyList<string> arguments,
+        bool includeFileChanges,
+        IReadOnlyList<BranchName> branches,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (includeFileChanges)
+        {
+            await foreach (var commit in ReadNameStatusAsync(
+                repositoryPath,
+                arguments,
+                branches,
+                cancellationToken))
+            {
+                yield return commit;
+            }
+
+            yield break;
+        }
+
+        await foreach (var commit in ReadMetadataAsync(
+           repositoryPath,
+           arguments,
+           branches,
+           cancellationToken))
+        {
+            yield return commit;
+        }
+    }
+
+    /// <summary>
+    /// Reads commit metadata from git log output.
+    /// </summary>
+    private static async IAsyncEnumerable<CommitData> ReadMetadataAsync(
+        string repositoryPath,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<BranchName> branches,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using var process = GitCliProcessRunner.Create(repositoryPath, arguments);
+
+        process.Start();
+
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        string[]? currentFields = null;
+
+        while (await process.StandardOutput.ReadLineAsync(cancellationToken) is { } line)
+        {
+            if (line.Length == 0 || line[0] != RecordSeparator)
+                continue;
+
+            var pending = MapCommit(currentFields, null, branches);
+
+            if (pending is not null)
+                yield return pending;
+
+            currentFields = line[1..].Split(UnitSeparator, 5);
+        }
+
+        var finalCommit = MapCommit(currentFields, null, branches);
+
+        if (finalCommit is not null)
+            yield return finalCommit;
+
+        await EnsureSuccessAsync(process, errorTask, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads commit metadata and file changes from git log output.
+    /// </summary>
+    private static async IAsyncEnumerable<CommitData> ReadNameStatusAsync(
+        string repositoryPath,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<BranchName> branches,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using var process = GitCliProcessRunner.Create(repositoryPath, arguments);
+
+        process.Start();
+
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        string[]? currentFields = null;
+        List<FileChange>? currentFileChanges = null;
+
+        string? pendingStatus = null;
+        string? pendingOldPath = null;
+
+        await foreach (var token in ReadNullSeparatedTokensAsync(
+            process.StandardOutput.BaseStream,
+            cancellationToken))
+        {
+            if (token.Length == 0)
+                continue;
+
+            if (LooksLikeCommitToken(token))
+            {
+                var pending = MapCommit(currentFields, currentFileChanges, branches);
+
+                if (pending is not null)
+                    yield return pending;
+
+                var payload = token[1..];
+                var statusStart = payload.LastIndexOf('\n');
+
+                if (statusStart >= 0)
+                {
+                    currentFields = payload[..statusStart].Split(UnitSeparator, 5);
+                    pendingStatus = payload[(statusStart + 1)..];
+                }
+                else
+                {
+                    currentFields = payload.Split(UnitSeparator, 5);
+                    pendingStatus = null;
+                }
+
+                currentFileChanges = [];
+                pendingOldPath = null;
+
+                continue;
+            }
+
+            if (currentFileChanges is null)
+                continue;
+
+            if (pendingStatus is null)
+            {
+                pendingStatus = token;
+                continue;
+            }
+
+            var kind = MapChangeKind(pendingStatus);
+
+            if (kind == FileChangeKind.Renamed && pendingOldPath is null)
+            {
+                pendingOldPath = token;
+                continue;
+            }
+
+            var fileChange = CreateFileChange(
+                pendingStatus,
+                token,
+                kind == FileChangeKind.Renamed
+                    ? pendingOldPath
+                    : null);
+
+            if (fileChange is not null)
+                currentFileChanges.Add(fileChange);
+
+            pendingStatus = null;
+            pendingOldPath = null;
+        }
+
+        var finalCommit = MapCommit(currentFields, currentFileChanges, branches);
+
+        if (finalCommit is not null)
+            yield return finalCommit;
+
+        await EnsureSuccessAsync(process, errorTask, cancellationToken);
+    }
+
+    /// <summary>
+    /// Verifies successful Git process completion.
+    /// </summary>
+    private static async Task EnsureSuccessAsync(
+        System.Diagnostics.Process process,
+        Task<string> errorTask,
+        CancellationToken cancellationToken)
+    {
+        await process.WaitForExitAsync(cancellationToken);
+
+        var error = await errorTask;
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(error)
+                    ? "Failed to read repository with Git CLI"
+                    : error.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Reads null-separated UTF-8 tokens from a stream.
+    /// </summary>
+    private static async IAsyncEnumerable<string> ReadNullSeparatedTokensAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var buffer = new byte[32768];
+        var leftover = new List<byte>();
+
+        while (true)
+        {
+            var bytesRead = await stream.ReadAsync(buffer, cancellationToken);
+
+            if (bytesRead == 0)
+                break;
+
+            var startIndex = 0;
+
+            while (startIndex < bytesRead)
+            {
+                var nullIndex = Array.IndexOf(
+                    buffer,
+                    (byte)0,
+                    startIndex,
+                    bytesRead - startIndex);
+
+                if (nullIndex >= 0)
+                {
+                    var length = nullIndex - startIndex;
+
+                    string token;
+
+                    if (leftover.Count > 0)
+                    {
+                        for (var i = 0; i < length; i++)
+                            leftover.Add(buffer[startIndex + i]);
+
+                        token = Encoding.UTF8.GetString(leftover.ToArray());
+
+                        leftover.Clear();
+                    }
+                    else
+                    {
+                        token = Encoding.UTF8.GetString(
+                            buffer,
+                            startIndex,
+                            length);
+                    }
+
+                    yield return token;
+
+                    startIndex = nullIndex + 1;
+                }
+                else
+                {
+                    var length = bytesRead - startIndex;
+
+                    for (var i = 0; i < length; i++)
+                        leftover.Add(buffer[startIndex + i]);
+
+                    break;
+                }
+            }
+        }
+
+        if (leftover.Count > 0)
+            yield return Encoding.UTF8.GetString(leftover.ToArray());
+    }
+
+    /// <summary>
+    /// Detects commit record boundaries in token streams.
+    /// </summary>
+    private static bool LooksLikeCommitToken(string token)
+    {
+        if (token.Length < 42 || token[0] != RecordSeparator)
+            return false;
+
+        for (var index = 1; index <= 40; index++)
+        {
+            if (!Uri.IsHexDigit(token[index]))
+                return false;
+        }
+
+        return token[41] == UnitSeparator;
+    }
+
+    /// <summary>
+    /// Converts parsed git log fields into commit data.
+    /// </summary>
+    private static CommitData? MapCommit(
+        string[]? fields,
+        IReadOnlyList<FileChange>? fileChanges,
+        IReadOnlyList<BranchName> branches)
+    {
+        if (fields is null || fields.Length < 5)
+            return null;
+
+        var shaResult = CommitSha.Create(fields[0]);
+        var authorResult = ActorName.Create(fields[1]);
+
+        var timestampResult = long.TryParse(fields[2], out var unixSeconds)
+            ? Timestamp.Create(unixSeconds)
+            : Result<Timestamp>.Failure("Invalid commit timestamp");
+
+        if (shaResult.IsFailure ||
+            authorResult.IsFailure ||
+            timestampResult.IsFailure)
+        {
+            return null;
+        }
+
+        var parentShas = fields[3]
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(CommitSha.Create)
+            .Where(result => result.IsSuccess)
+            .Select(result => result.Value)
+            .ToList();
+
+        fileChanges = parentShas.Count > 0
+            ? fileChanges ?? []
+            : [];
+
+        return new CommitData(
+            Sha: shaResult.Value,
+            Author: authorResult.Value,
+            Timestamp: timestampResult.Value,
+            Message: fields[4],
+            ParentShas: parentShas,
+            FileChanges: fileChanges,
+            Branches: branches,
+            IsMerge: parentShas.Count > 1);
+    }
+
+    /// <summary>
+    /// Creates a file change from parsed git status data.
+    /// </summary>
+    private static FileChange? CreateFileChange(
+        string status,
+        string pathValue,
+        string? oldPathValue)
+    {
+        var kind = MapChangeKind(status);
+
+        var pathResult = FilePath.Create(pathValue);
+
+        if (pathResult.IsFailure)
+            return null;
+
+        FilePath? oldPath = null;
+
+        if (kind == FileChangeKind.Renamed &&
+            oldPathValue is not null)
+        {
+            var oldPathResult = FilePath.Create(oldPathValue);
+
+            if (oldPathResult.IsSuccess)
+                oldPath = oldPathResult.Value;
+        }
+
+        return new FileChange(
+            Path: pathResult.Value,
+            Kind: kind,
+            OldPath: oldPath);
+    }
+
+    /// <summary>
+    /// Converts git status codes into domain change types.
+    /// </summary>
+    private static FileChangeKind MapChangeKind(string status) =>
+        status[0] switch
+        {
+            'A' => FileChangeKind.Added,
+            'D' => FileChangeKind.Deleted,
+            'R' => FileChangeKind.Renamed,
+            _ => FileChangeKind.Modified
+        };
+}

--- a/src/GIt/History/GitCli/GitCliProcessRunner.cs
+++ b/src/GIt/History/GitCli/GitCliProcessRunner.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace ChangeTrace.GIt.History.GitCli;
+
+/// <summary>
+/// Runs Git CLI commands and captures their output.
+/// </summary>
+internal static class GitCliProcessRunner
+{
+    /// <summary>
+    /// Runs a Git command and captures process output.
+    /// </summary>
+    public static async Task<GitCliResult> RunAsync(
+        string repositoryPath,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        using var process = Create(repositoryPath, arguments);
+
+        process.Start();
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new GitCliResult(
+            process.ExitCode,
+            await outputTask,
+            await errorTask);
+    }
+
+    /// <summary>
+    /// Creates a configured Git process.
+    /// </summary>
+    public static Process Create(
+        string repositoryPath,
+        IReadOnlyList<string> arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add("-C");
+        process.StartInfo.ArgumentList.Add(repositoryPath);
+
+        foreach (var argument in arguments)
+            process.StartInfo.ArgumentList.Add(argument);
+
+        return process;
+    }
+}
+
+/// <summary>
+/// Git CLI command result.
+/// </summary>
+internal readonly record struct GitCliResult(
+    int ExitCode,
+    string Output,
+    string Error);

--- a/src/GIt/Interfaces/ICommitHistoryReaderBackend.cs
+++ b/src/GIt/Interfaces/ICommitHistoryReaderBackend.cs
@@ -1,0 +1,24 @@
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+using ChangeTrace.GIt.Options;
+
+namespace ChangeTrace.GIt.Interfaces;
+
+/// <summary>
+/// Reads commit history from a Git repository.
+/// </summary>
+internal interface ICommitHistoryReaderBackend
+{
+    /// <summary>
+    /// Backend type used by this reader.
+    /// </summary>
+    GitHistoryReaderBackend Backend { get; }
+
+    /// <summary>
+    /// Reads commit history as an asynchronous stream.
+    /// </summary>
+    Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken);
+}

--- a/src/GIt/Interfaces/IGitRepositoryReader.cs
+++ b/src/GIt/Interfaces/IGitRepositoryReader.cs
@@ -29,6 +29,15 @@ internal interface IGitRepositoryReader
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Streams commits from a local Git repository without requiring the reader to materialize
+    /// the full history before consumers can start processing it.
+    /// </summary>
+    Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Clones a remote Git repository to a local path.
     /// </summary>
     /// <param name="url">Remote repository URL.</param>

--- a/src/GIt/Interfaces/ITimelineBuilder.cs
+++ b/src/GIt/Interfaces/ITimelineBuilder.cs
@@ -11,4 +11,9 @@ internal interface ITimelineBuilder
     Result<Timeline> Build(
         IReadOnlyList<CommitData> commits,
         TimelineBuilderOptions options);
+
+    Task<Result<Timeline>> BuildAsync(
+        IAsyncEnumerable<CommitData> commits,
+        TimelineBuilderOptions options,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GIt/Options/ExportOptions.cs
+++ b/src/GIt/Options/ExportOptions.cs
@@ -11,6 +11,7 @@ namespace ChangeTrace.GIt.Options;
 /// </summary>
 /// <param name="IncludeFileChanges">
 /// Whether to include detailed file-level changes for commits. Defaults to <c>true</c>.
+/// This is one of the main export cost drivers on large repositories.
 /// </param>
 /// <param name="IncludeBranchEvents">
 /// Whether to generate branch-related events in the timeline. Defaults to <c>true</c>.
@@ -40,6 +41,16 @@ internal sealed record ExportOptions
     public bool IncludeBranchEvents { get; init; } = true;
     public bool IncludeMergeDetection { get; init; } = true;
     public bool EnrichWithPullRequests { get; init; } = true;
+    /// <summary>
+    /// History backend used for commit and file-change extraction.
+    /// <see cref="GitHistoryReaderBackend.GitCli"/> is usually the better choice for larger local histories.
+    /// </summary>
+    public GitHistoryReaderBackend HistoryBackend { get; init; } = GitHistoryReaderBackend.LibGit2Sharp;
+    /// <summary>
+    /// Controls rename detection for Git CLI file change extraction.
+    /// Disabling it improves throughput but reports renames as delete/add pairs.
+    /// </summary>
+    public bool DetectRenames { get; init; } = true;
     public int MaxCommits { get; init; } = 0;
     public DateTimeOffset? StartDate { get; init; }
     public DateTimeOffset? EndDate { get; init; }

--- a/src/GIt/Options/GitReaderOptions.cs
+++ b/src/GIt/Options/GitReaderOptions.cs
@@ -1,6 +1,15 @@
 namespace ChangeTrace.GIt.Options;
 
 /// <summary>
+/// Selects the backend used to read commit history from a local Git repository.
+/// </summary>
+internal enum GitHistoryReaderBackend
+{
+    LibGit2Sharp,
+    GitCli
+}
+
+/// <summary>
 /// Options controlling how a Git repository is read.
 /// <para>
 /// These options are used by GitRepositoryReader to filter commits,
@@ -19,9 +28,23 @@ namespace ChangeTrace.GIt.Options;
 /// <param name="EndDate">
 /// Optional end date filter; only commits on or before this date are included.
 /// </param>
+/// <param name="Backend">
+/// History reader backend. Defaults to <see cref="GitHistoryReaderBackend.LibGit2Sharp"/> for existing behavior.
+/// </param>
+/// <param name="DetectRenames">
+/// Whether Git CLI file-change extraction should detect renames. Defaults to <c>true</c> for fidelity.
+/// Disabling it improves throughput but reports renames as separate delete/add changes.
+/// </param>
+/// <param name="IncludeBranches">
+/// Whether to populate branch metadata for each commit. Defaults to <c>true</c>.
+/// Disable it when branch and merge events are not needed to avoid extra branch graph traversal.
+/// </param>
 internal sealed record GitReaderOptions(
     bool IncludeFileChanges = true,
     int MaxCommits = 0,
     DateTimeOffset? StartDate = null,
-    DateTimeOffset? EndDate = null
+    DateTimeOffset? EndDate = null,
+    GitHistoryReaderBackend Backend = GitHistoryReaderBackend.LibGit2Sharp,
+    bool DetectRenames = true,
+    bool IncludeBranches = true
 );

--- a/src/GIt/Services/GitRepositoryReader.cs
+++ b/src/GIt/Services/GitRepositoryReader.cs
@@ -1,150 +1,149 @@
-using System.Collections.Concurrent;
 using ChangeTrace.Configuration.Discovery;
 using ChangeTrace.Core;
-using ChangeTrace.Core.Enums;
 using ChangeTrace.Core.Models;
 using ChangeTrace.Core.Results;
+using ChangeTrace.GIt.History.Backends;
 using ChangeTrace.GIt.Interfaces;
 using ChangeTrace.GIt.Options;
 using LibGit2Sharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace ChangeTrace.GIt.Services;
 
-
 /// <summary>
-/// Service for reading Git repositories using <c>LibGit2Sharp</c>.
-/// Provides commit history, branch mapping, and optional file changes.
+/// Facade for repository history reading and cloning.
+/// Backend-specific history extraction lives in dedicated readers.
 /// </summary>
-/// <remarks>
-/// Implements <see cref="IGitRepositoryReader"/>.  
-/// Branch detection uses commit ancestry to ensure correctness.  
-/// Clone operations supported with logging and progress reporting.
-/// </remarks>
 [AutoRegister(ServiceLifetime.Singleton)]
-internal sealed class GitRepositoryReader(ILogger<GitRepositoryReader> logger) : IGitRepositoryReader
+internal sealed class GitRepositoryReader : IGitRepositoryReader
 {
-    /// <summary>
-    /// Reads commits from repository with optional file change tracking.
-    /// </summary>
-    /// <param name="repositoryPath">Path to local Git repository.</param>
-    /// <param name="options">Reader options, including date range, max commits, and file change inclusion.</param>
-    /// <param name="cancellationToken">Token to cancel operation.</param>
-    /// <returns>
-    /// Result containing readonly list of <see cref="CommitData"/> on success, 
-    /// or failure with error message.
-    /// </returns>
+    private static readonly Lazy<bool> GitCliAvailable = new(IsGitCliAvailableCore);
+
+    private readonly ILogger<GitRepositoryReader> _logger;
+    private readonly IReadOnlyDictionary<GitHistoryReaderBackend, ICommitHistoryReaderBackend> _historyReaders;
+
+    public GitRepositoryReader(ILogger<GitRepositoryReader> logger)
+    {
+        _logger = logger;
+        _historyReaders = new ICommitHistoryReaderBackend[]
+            {
+                new LibGit2SharpHistoryReader(logger),
+                new GitCliHistoryReader(logger)
+            }
+            .ToDictionary(reader => reader.Backend);
+    }
+
     public async Task<Result<IReadOnlyList<CommitData>>> ReadCommitsAsync(
         string repositoryPath,
         GitReaderOptions options,
         CancellationToken cancellationToken = default)
     {
-        return await Task.Run(async () =>
+        var streamResult = await ReadCommitsStreamAsync(repositoryPath, options, cancellationToken);
+        if (streamResult.IsFailure)
+            return Result<IReadOnlyList<CommitData>>.Failure(streamResult.Error!);
+
+        try
         {
-            if (!Repository.IsValid(repositoryPath))
-                return Result<IReadOnlyList<CommitData>>.Failure("Invalid Git repository");
-
-            try
+            var commits = new List<CommitData>();
+            await foreach (var commit in streamResult.Value.WithCancellation(cancellationToken))
             {
-                using var repo = new Repository(repositoryPath);
-                var commitToBranches = BuildCommitToBranchMap(repo);
-                var commitResults = new ConcurrentBag<CommitData>();
-                var filter = new CommitFilter {  SortBy = CommitSortStrategies.Time | CommitSortStrategies.Topological };
-
-                var commits = repo.Commits.QueryBy(filter)
-                    .Where(c => IsCommitInRange(c, options))
-                    .Take(options.MaxCommits > 0 ? options.MaxCommits : int.MaxValue)
-                    .ToList();
-                var semaphore = new SemaphoreSlim(4);
-
-                var tasks = commits.Select(async commit =>
-                {
-                    await semaphore.WaitAsync(cancellationToken);
-                    try
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                            return;
-
-                        var result = MapCommit(repo, commit, options.IncludeFileChanges, commitToBranches);
-                        if (result.IsSuccess)
-                            commitResults.Add(result.Value);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
-                }).ToArray();
-                
-                await Task.WhenAll(tasks);
-                
-                var orderedCommits = commitResults
-                    .OrderBy(c => c.Timestamp.UnixSeconds)
-                    .ToList()
-                    .AsReadOnly();
-
-                logger.LogInformation("Read {Count} commits", orderedCommits.Count);
-                return Result<IReadOnlyList<CommitData>>.Success(orderedCommits);
+                commits.Add(commit);
             }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to read repository");
-                return Result<IReadOnlyList<CommitData>>.Failure("Failed to read repository", ex);
-            }
-        }, cancellationToken);
+
+            var orderedCommits = commits
+                .OrderBy(commit => commit.Timestamp.UnixSeconds)
+                .ToList()
+                .AsReadOnly();
+
+            _logger.LogInformation("Read {Count} commits", orderedCommits.Count);
+            return Result<IReadOnlyList<CommitData>>.Success(orderedCommits);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read repository");
+            return Result<IReadOnlyList<CommitData>>.Failure("Failed to read repository", ex);
+        }
     }
 
-    /// <summary>
-    /// Determines if commit is within configured date range.
-    /// </summary>
-    private static bool IsCommitInRange(Commit commit, GitReaderOptions options)
+    public Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken = default)
     {
-        return (!options.StartDate.HasValue || commit.Author.When >= options.StartDate.Value)
-               && (!options.EndDate.HasValue || commit.Author.When <= options.EndDate.Value);
-    }
-    
-    /// <summary>
-    /// Builds mapping from commit SHA to branch names.
-    /// </summary>
-    /// <param name="repo">Repository to analyze.</param>
-    /// <returns>Dictionary mapping commit SHA to list of branches containing it.</returns>
-    private Dictionary<string, List<string>> BuildCommitToBranchMap(Repository repo)
-    {
-        var map = new Dictionary<string, List<string>>();
-        const int maxWalk = 1000;
-        
-        foreach (var branch in repo.Branches.Where(b => !b.IsRemote && b.Tip != null))
-        {
-            var branchName = branch.FriendlyName;
-            AddToMap(map, branch.Tip.Sha, branchName);
+        if (!ShouldPreferGitCli(options))
+            return TryReadWithBackendAsync(repositoryPath, options, cancellationToken);
 
-            foreach (var (commit, index) in repo.Commits
-                         .QueryBy((new CommitFilter { IncludeReachableFrom = branch.Tip, SortBy = CommitSortStrategies.Topological }))
-                         .Select((c, i) => (c, i)))
+        return ReadCommitsStreamCoreAsync(repositoryPath, options, cancellationToken);
+    }
+
+    private async Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamCoreAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (ShouldPreferGitCli(options))
+        {
+            var gitCliOptions = options with { Backend = GitHistoryReaderBackend.GitCli };
+            var gitCliResult = await TryReadWithBackendAsync(repositoryPath, gitCliOptions, cancellationToken);
+            if (gitCliResult.IsSuccess)
             {
-                AddToMap(map, commit.Sha, branchName);
-                if (index + 1 >= maxWalk) break;
+                _logger.LogInformation(
+                    "Using Git CLI backend for file-change extraction throughput.");
+                return gitCliResult;
             }
+
+            _logger.LogWarning(
+                "Git CLI backend failed for file-change extraction, falling back to LibGit2Sharp: {Error}",
+                gitCliResult.Error);
         }
 
-        logger.LogDebug("Built branch map with {Count} commits", map.Count);
-        return map;
+        return await TryReadWithBackendAsync(repositoryPath, options, cancellationToken);
     }
-    
-    /// <summary>
-    /// Adds commit SHA to the branch mapping.
-    /// </summary>
-    private static void AddToMap(Dictionary<string, List<string>> map, string sha, string branchName) =>
-        (map.TryGetValue(sha, out var list) ? list : map[sha] = [])
-            .Add(branchName);
-    
-    /// <summary>
-    /// Clones remote repository to local path.
-    /// </summary>
-    /// <param name="url">Repository URL.</param>
-    /// <param name="destinationPath">Destination folder for clone.</param>
-    /// <param name="cancellationToken">Token to cancel operation.</param>
-    /// <returns>Result indicating success or failure.</returns>
+
+    private bool ShouldPreferGitCli(GitReaderOptions options)
+        => options.Backend == GitHistoryReaderBackend.LibGit2Sharp
+           && options.IncludeFileChanges
+           && GitCliAvailable.Value;
+
+    private Task<Result<IAsyncEnumerable<CommitData>>> TryReadWithBackendAsync(
+        string repositoryPath,
+        GitReaderOptions options,
+        CancellationToken cancellationToken)
+    {
+        return !_historyReaders.TryGetValue(options.Backend, out var reader)
+            ? Task.FromResult(Result<IAsyncEnumerable<CommitData>>.Failure($"Unsupported Git history backend: {options.Backend}"))
+            : reader.ReadCommitsStreamAsync(repositoryPath, options, cancellationToken);
+    }
+
+    private static bool IsGitCliAvailableCore()
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.StartInfo.ArgumentList.Add("--version");
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<Result> CloneAsync(
         string url,
         string destinationPath,
@@ -154,7 +153,7 @@ internal sealed class GitRepositoryReader(ILogger<GitRepositoryReader> logger) :
         {
             try
             {
-                logger.LogInformation("Cloning {Url} to {Path}", url, destinationPath);
+                _logger.LogInformation("Cloning {Url} to {Path}", url, destinationPath);
 
                 if (Directory.Exists(destinationPath))
                     Directory.Delete(destinationPath, true);
@@ -169,198 +168,27 @@ internal sealed class GitRepositoryReader(ILogger<GitRepositoryReader> logger) :
                         {
                             if (progress.TotalObjects > 0 && progress.ReceivedObjects % 100 == 0)
                             {
-                                logger.LogDebug("Clone progress: {Received}/{Total}",
-                                    progress.ReceivedObjects, progress.TotalObjects);
+                                _logger.LogDebug(
+                                    "Clone progress: {Received}/{Total}",
+                                    progress.ReceivedObjects,
+                                    progress.TotalObjects);
                             }
+
                             return !cancellationToken.IsCancellationRequested;
                         }
                     }
                 };
+
                 Repository.Clone(url, destinationPath, options);
-                
-                logger.LogInformation("Clone complete");
+
+                _logger.LogInformation("Clone complete");
                 return Result.Success();
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Clone failed");
+                _logger.LogError(ex, "Clone failed");
                 return Result.Failure("Clone failed", ex);
             }
         }, cancellationToken);
     }
-
-    /// <summary>
-    /// Maps <see cref="Commit"/> to <see cref="CommitData"/> object.
-    /// </summary>
-    /// <param name="repo">Repository containing the commit.</param>
-    /// <param name="commit">Commit to map.</param>
-    /// <param name="includeFileChanges">Whether to include file level changes.</param>
-    /// <param name="commitToBranches">Precomputed commit-to-branch mapping.</param>
-    /// <returns>Result containing <see cref="CommitData"/> on success.</returns>
-    private Result<CommitData> MapCommit(
-        Repository repo, 
-        Commit commit, 
-        bool includeFileChanges,
-        Dictionary<string, List<string>> commitToBranches)
-    {
-        try
-        {
-            var basicsResult = MapCommitBasics(commit);
-            if (basicsResult.IsFailure)
-                return Result<CommitData>.Failure(basicsResult.Error!);
-
-            var (sha, author, ts, parentShas) = basicsResult.Value;
-            var fileChanges = includeFileChanges
-                ? GetFileChanges(repo, commit) : [];
-            var branches = GetBranches(commit, repo, commitToBranches);
-
-            if (!branches.Any())
-                logger.LogTrace("No branches found for commit {Sha}", commit.Sha[..8]);
-
-            var commitData = new CommitData(
-                Sha: sha,
-                Author: author,
-                Timestamp: ts,
-                Message: commit.MessageShort,
-                ParentShas: parentShas,
-                FileChanges: fileChanges,
-                Branches: branches,
-                IsMerge: commit.Parents.Count() > 1
-            );
-
-            return Result<CommitData>.Success(commitData);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to map commit {Sha}", commit.Sha[..8]);
-            return Result<CommitData>.Failure($"Failed to map commit {commit.Sha[..8]}", ex);
-        }
-    }
-    
-    /// <summary>
-    /// Maps basic commit data: SHA, author, timestamp, and parent SHAs.
-    /// </summary>
-    /// <param name="commit">Commit to map.</param>
-    /// <returns>
-    /// Result containing tuple of commit SHA, author name, timestamp, and parent SHAs on success.
-    /// </returns>
-    private static Result<(CommitSha sha, ActorName author, Timestamp ts, List<CommitSha> parents)> MapCommitBasics(Commit commit)
-    {
-        var shaResult = CommitSha.Create(commit.Sha);
-        if (shaResult.IsFailure) return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(shaResult.Error!);
-
-        var authorResult = ActorName.Create(commit.Author.Name);
-        if (authorResult.IsFailure) return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(authorResult.Error!);
-
-        var timestampResult = Timestamp.Create(commit.Author.When.ToUnixTimeSeconds());
-        if (timestampResult.IsFailure) return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Failure(timestampResult.Error!);
-
-        var parentShas = commit.Parents
-            .Select(p => CommitSha.Create(p.Sha))
-            .Where(r => r.IsSuccess)
-            .Select(r => r.Value)
-            .ToList();
-
-        return Result<(CommitSha, ActorName, Timestamp, List<CommitSha>)>.Success(
-            (shaResult.Value, authorResult.Value, timestampResult.Value, parentShas)
-        );
-    }
-    
-    /// <summary>
-    /// Retrieves branches containing given commit.
-    /// Falls back to HEAD if no mapping found.
-    /// </summary>
-    /// <param name="commit">Commit to locate branches for.</param>
-    /// <param name="repo">Repository context.</param>
-    /// <param name="commitToBranches">Precomputed commit to branch mapping.</param>
-    /// <returns>List of <see cref="BranchName"/> instances.</returns>
-    private List<BranchName> GetBranches(Commit commit, Repository repo, Dictionary<string, List<string>> commitToBranches)
-    {
-        if (commitToBranches.TryGetValue(commit.Sha, out var branchNames))
-        {
-            return branchNames
-                .Select(BranchName.Create)
-                .Where(r => r.IsSuccess)
-                .Select(r => r.Value)
-                .ToList();
-        }
-
-        // fallback to HEAD
-        try
-        {
-            var head = repo.Head;
-            if (head != null && !head.IsRemote)
-            {
-                var branchResult = BranchName.Create(head.FriendlyName);
-                if (branchResult.IsSuccess) return [branchResult.Value];
-            }
-        }
-        catch
-        {
-            // ignore HEAD errors
-        }
-
-        return [];
-    }
-    
-    /// <summary>
-    /// Retrieves file level changes for commit.
-    /// </summary>
-    /// <param name="repo">Repository context.</param>
-    /// <param name="commit">Commit to inspect.</param>
-    /// <returns>Readonly list of <see cref="FileChange"/> objects.</returns>
-    private IReadOnlyList<FileChange> GetFileChanges(Repository repo, Commit commit)
-    {
-        try
-        {
-            var parent = commit.Parents.FirstOrDefault();
-            if (parent == null)
-                return [];
-
-            var changes = repo.Diff.Compare<TreeChanges>(parent.Tree, commit.Tree);
-            var fileChanges = new List<FileChange>();
-
-            foreach (var change in changes)
-            {
-                var pathResult = FilePath.Create(change.Path);
-                if (pathResult.IsFailure)
-                    continue;
-
-                FilePath? oldPath = null;
-                if (change is { Status: ChangeKind.Renamed, OldPath: not null })
-                {
-                    var oldPathResult = FilePath.Create(change.OldPath);
-                    if (oldPathResult.IsSuccess)
-                        oldPath = oldPathResult.Value;
-                }
-                
-                fileChanges.Add( new FileChange(
-                    Path: pathResult.Value,
-                    Kind: MapChangeKind(change.Status),
-                    OldPath: oldPath
-                ));
-            }
-
-            return fileChanges.AsReadOnly();
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to get file changes for {Sha}", commit.Sha[..8]);
-            return [];
-        }
-    }
-
-    /// <summary>
-    /// Maps <see cref="ChangeKind"/> from LibGit2Sharp to <see cref="FileChangeKind"/>.
-    /// </summary>
-    /// <param name="kind">LibGit2Sharp change kind.</param>
-    /// <returns>Corresponding <see cref="FileChangeKind"/> value.</returns>
-    private static FileChangeKind MapChangeKind(ChangeKind kind) => kind switch
-    {
-        ChangeKind.Added => FileChangeKind.Added,
-        ChangeKind.Modified => FileChangeKind.Modified,
-        ChangeKind.Deleted => FileChangeKind.Deleted,
-        ChangeKind.Renamed => FileChangeKind.Renamed,
-        _ => FileChangeKind.Modified
-    };
 }

--- a/src/GIt/Services/RepositoryExporter.cs
+++ b/src/GIt/Services/RepositoryExporter.cs
@@ -54,27 +54,25 @@ internal sealed class RepositoryExporter(
 
             var repoPath = pathResult.Value;
             progress?.Invoke("Prepare", 1, 4, "Repository ready");
-            
-            var repositoryId = ExtractRepositoryId(pathOrUrl);
-            // Step 2: Read commits
-            var commitsResult = await ReadCommitsStep(repoPath, options, progress, cancellationToken);
-            if (commitsResult.IsFailure)
-                return Result<Timeline>.Failure(commitsResult.Error!);
 
-            var commits = commitsResult.Value;
-            
-            // Step 3: Build timeline
-            var timelineResult = BuildTimelineStep(commits, repositoryId, options, progress);
+            var repositoryId = ExtractRepositoryId(pathOrUrl);
+            // Step 2 and 3: Stream commits and build timeline.
+            var timelineResult = await BuildTimelineFromRepositoryStep(
+                repoPath,
+                repositoryId,
+                options,
+                progress,
+                cancellationToken);
             if (timelineResult.IsFailure)
                 return Result<Timeline>.Failure(timelineResult.Error!);
-            
+
             var timeline = timelineResult.Value;
             progress?.Invoke("Build", 3, 4, $"Built {timeline.Count} events");
 
             // Step 4 and 5 Enrich with PR data & Normalize
             //await EnrichStep(timeline, pathOrUrl, options, progress, cancellationToken);
-            TimelineNormalizer.Normalize(timeline); 
-            
+            TimelineNormalizer.Normalize(timeline);
+
             progress?.Invoke("Complete", 4, 4, "Export complete");
 
             return Result<Timeline>.Success(timeline);
@@ -106,7 +104,7 @@ internal sealed class RepositoryExporter(
         CancellationToken cancellationToken = default)
     {
         var exportResult = await ExportAsync(pathOrUrl, options, progress, cancellationToken);
-        
+
         if (exportResult.IsFailure)
             return Result.Failure(exportResult.Error!);
 
@@ -139,7 +137,7 @@ internal sealed class RepositoryExporter(
         if (IsGitUrl(pathOrUrl))
         {
             logger.LogInformation("Cloning repository: {Url}", pathOrUrl);
-            
+
             var tempPath = Path.Combine(Path.GetTempPath(), "ChangeTrace", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempPath);
 
@@ -154,56 +152,34 @@ internal sealed class RepositoryExporter(
             : Result<string>.Success(pathOrUrl);
     }
 
-    /// <summary>
-    /// Reads commits from  repository path using <see cref="IGitRepositoryReader"/>.
-    /// </summary>
-    /// <param name="repoPath">Local repository path.</param>
-    /// <param name="options">Export options controlling commit selection.</param>
-    /// <param name="progress">Optional progress callback to report read progress.</param>
-    /// <param name="ct">Cancellation token.</param>
-    private async Task<Result<IReadOnlyList<CommitData>>> ReadCommitsStep(
+    private async Task<Result<Timeline>> BuildTimelineFromRepositoryStep(
         string repoPath,
+        RepositoryId? repositoryId,
         ExportOptions options,
         ProgressCallback? progress,
         CancellationToken ct)
     {
         progress?.Invoke("Read", 1, 4, "Reading commits...");
-        
-        var commitsResult = await gitReader.ReadCommitsAsync(
+
+        var backend = SelectHistoryBackend(repoPath, options);
+
+        var commitsResult = await gitReader.ReadCommitsStreamAsync(
             repoPath,
             new GitReaderOptions(
                 IncludeFileChanges: options.IncludeFileChanges,
                 MaxCommits: options.MaxCommits,
                 StartDate: options.StartDate,
-                EndDate: options.EndDate
+                EndDate: options.EndDate,
+                Backend: backend,
+                DetectRenames: options.DetectRenames,
+                IncludeBranches: options.IncludeBranchEvents || options.IncludeMergeDetection
             ),
             ct
         );
 
-        if (commitsResult.IsFailure) return commitsResult;
+        if (commitsResult.IsFailure)
+            return Result<Timeline>.Failure(commitsResult.Error!);
 
-        var commits = commitsResult.Value;
-        progress?.Invoke("Read", 2, 4, $"Read {commits.Count} commits");
-
-        return Result<IReadOnlyList<CommitData>>.Success(commits);
-    }
-
-    /// <summary>
-    /// Builds timeline from list of commits using <see cref="ITimelineBuilder"/>.
-    /// </summary>
-    /// <param name="commits">List of commits to build timeline from.</param>
-    /// <param name="repositoryId"></param>
-    /// <param name="options">Export options influencing timeline construction.</param>
-    /// <param name="progress">Optional progress callback.</param>
-    /// <returns>
-    /// A <see cref="Result{Timeline}"/> containing the built timeline or error.
-    /// </returns>
-    private Result<Timeline> BuildTimelineStep(
-        IReadOnlyList<CommitData> commits, 
-        RepositoryId repositoryId,
-        ExportOptions options,
-        ProgressCallback? progress)
-    {
         progress?.Invoke("Build", 2, 4, "Building timeline...");
 
         var builderOptions = new TimelineBuilderOptions(
@@ -212,10 +188,39 @@ internal sealed class RepositoryExporter(
             IncludeMergeDetection: options.IncludeMergeDetection,
             RepositoryId: repositoryId
         );
-  
-        return timelineBuilder.Build(commits, builderOptions);
+
+        return await timelineBuilder.BuildAsync(commitsResult.Value, builderOptions, ct);
     }
-    
+
+    private GitHistoryReaderBackend SelectHistoryBackend(
+        string repoPath,
+        ExportOptions options)
+    {
+        if (options.HistoryBackend != GitHistoryReaderBackend.LibGit2Sharp)
+            return options.HistoryBackend;
+
+        if (!IsGitCliAvailable())
+            return GitHistoryReaderBackend.LibGit2Sharp;
+
+        if (options.IncludeFileChanges)
+        {
+            logger.LogInformation(
+                "IncludeFileChanges enabled. Automatically switching to Git CLI history backend for file change extraction throughput.");
+            return GitHistoryReaderBackend.GitCli;
+        }
+
+        var commitCount = GetCommitCount(repoPath);
+        if (commitCount > 20000)
+        {
+            logger.LogWarning(
+                "Large repository detected ({Count} commits). Automatically switching to Git CLI streaming backend for performance.",
+                commitCount);
+            return GitHistoryReaderBackend.GitCli;
+        }
+
+        return GitHistoryReaderBackend.LibGit2Sharp;
+    }
+
     /// <summary>
     /// Enriches timeline with pull request data using <see cref="ITimelineEnricher"/>.
     /// </summary>
@@ -246,7 +251,7 @@ internal sealed class RepositoryExporter(
         else
             logger.LogWarning("PR enrichment failed: {Error}", enrichResult.Error);
     }
-    
+
     /// <summary>
     /// Determines if a string is a Git URL.
     /// </summary>
@@ -255,7 +260,7 @@ internal sealed class RepositoryExporter(
     private static bool IsGitUrl(string pathOrUrl) =>
          pathOrUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
                pathOrUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase);
-    
+
     /// <summary>
     /// Extracts repository owner and name from Git URL.
     /// </summary>
@@ -288,5 +293,68 @@ internal sealed class RepositoryExporter(
         }
 
         return null;
+    }
+
+    private static bool IsGitCliAvailable()
+    {
+        try
+        {
+            using var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.StartInfo.ArgumentList.Add("--version");
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int GetCommitCount(string repoPath)
+    {
+        try
+        {
+            using var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.StartInfo.ArgumentList.Add("-C");
+            process.StartInfo.ArgumentList.Add(repoPath);
+            process.StartInfo.ArgumentList.Add("rev-list");
+            process.StartInfo.ArgumentList.Add("--count");
+            process.StartInfo.ArgumentList.Add("HEAD");
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode == 0 && int.TryParse(output.Trim(), out var count))
+                return count;
+        }
+        catch
+        {
+            // Ignore
+        }
+
+        return 0;
     }
 }

--- a/src/GIt/Services/TimelineRepositoryMsgPack.cs
+++ b/src/GIt/Services/TimelineRepositoryMsgPack.cs
@@ -55,40 +55,41 @@ internal sealed class TimelineRepositoryMsgPack(
         logger.LogInformation("Timeline saved successfully ({Length} bytes)", bytes.Length);
             
             
-        var debugObject = new
-        {
-            Repository = timeline.RepositoryId != null
-                ? new
-                {
-                    timeline.RepositoryId.Owner,
-                    timeline.RepositoryId.Name
-                }
-                : null,
-            EventCount = timeline.Events.Count,
-            Events = timeline.Events.Select(evt => new
+            if ((logger.IsEnabled(LogLevel.Debug) || logger.GetType().Name.StartsWith("NullLogger")) && timeline.Events.Count <= 50000)
             {
-                Timestamp = evt.Core.Timestamp.UnixSeconds,
-                Actor = evt.Core.Actor?.Value,
-                Branch = evt.Branch?.Name?.Value,
-                BranchType = evt.Branch?.Type,
-                CommitSha = evt.Commit?.Sha?.Value,
-                CommitType = evt.Commit?.Type,
-                FilePath = evt.Metadata?.FilePath?.Value,
-                MetadataMessage = evt.Metadata?.Metadata,
-                Target = evt.Target
-            }).ToList()
-        };
-            var json = System.Text.Json.JsonSerializer.Serialize(
-                debugObject,
-                new System.Text.Json.JsonSerializerOptions
+                var debugObject = new
                 {
-                    WriteIndented = true
-                });
+                    Repository = timeline.RepositoryId != null
+                        ? new
+                        {
+                            timeline.RepositoryId.Owner,
+                            timeline.RepositoryId.Name
+                        }
+                        : null,
+                    EventCount = timeline.Events.Count,
+                    Events = timeline.Events.Select(evt => new
+                    {
+                        Timestamp = evt.Core.Timestamp.UnixSeconds,
+                        Actor = evt.Core.Actor?.Value,
+                        Branch = evt.Branch?.Name?.Value,
+                        BranchType = evt.Branch?.Type,
+                        CommitSha = evt.Commit?.Sha?.Value,
+                        CommitType = evt.Commit?.Type,
+                        FilePath = evt.Metadata?.FilePath?.Value,
+                        MetadataMessage = evt.Metadata?.Metadata,
+                        Target = evt.Target
+                    }).ToList()
+                };
+                var json = System.Text.Json.JsonSerializer.Serialize(
+                    debugObject,
+                    new System.Text.Json.JsonSerializerOptions
+                    {
+                        WriteIndented = true
+                    });
 
-            var debugPath = filePath + ".debug.json";
-            await File.WriteAllTextAsync(debugPath, json, cancellationToken);
-
-            
+                var debugPath = filePath + ".debug.json";
+                await File.WriteAllTextAsync(debugPath, json, cancellationToken);
+            }
             
             return Result.Success();
         }


### PR DESCRIPTION
## Summary

This PR does two concrete things in the codebase:

- refactors repository history reading behind backend specific readers and adds a Git CLI implementation with async commit streaming
- packages `ChangeTrace` as a .NET global tool and publishes the generated `.nupkg` in release workflows

Closes #30
Closes #7

## History Reading

- adds `GitHistoryReaderBackend` and backend selection to `GitReaderOptions`
- adds `ICommitHistoryReaderBackend` and moves history extraction behind dedicated backend implementations
- adds `IGitRepositoryReader.ReadCommitsStreamAsync(...)` so consumers can build timelines from `IAsyncEnumerable<CommitData>`
- adds `GitCliHistoryReader`, `GitCliProcessRunner` and `GitCliLogParser` for `git log`-based reading
- keeps `LibGit2SharpHistoryReader` as a separate backend instead of mixing both paths in `GitRepositoryReader`
- updates `GitRepositoryReader` to materialize from the stream API and to prefer Git CLI when file changes are requested and `git` is available

## Export and CLI

- updates `RepositoryExporter` to build timelines from streamed commits instead of a fully materialized commit list
- adds backend selection and rename detection to `ExportOptions`
- auto switches export to the Git CLI backend for file change exports, and for large local repositories when commit count is high
- adds `export --git-cli` and `export --no-renames`
- allows `changetrace export` without an explicit repository argument by resolving the current Git checkout
- when no workspace is active and no output path is provided, writes `<repo>.gittrace` into the current directory
- changes `show` from JSON dumping to opening the timeline player window for a `.gittrace` file

## Tool Packaging and Release

- enables `PackAsTool` in `ChangeTrace.csproj` and adds tool metadata, package output path and packaged README
- excludes runtime identifiers while packing the tool package
- adds `task tool:pack`, `tool:install`, `tool:update` and `tool:uninstall`
- adds a `tool-package` job in `.github/workflows/publish-artifacts.yml`
- passes `package_version` into the reusable publish workflow and derives it from the tag/ref name
- includes `.nupkg` files in prerelease artifacts, uploaded release assets and generated `SHA256SUMS.txt`
- ignores generated `nupkg/` output in `.gitignore`

## Coverage in This PR

- adds `GitRepositoryReaderGitCliTests` for Git CLI parity, date filtering, rename handling and quoted path parsing
- updates `RepositoryExporterTests` for streaming reads and automatic Git CLI selection
- adds benchmark coverage for Git CLI read modes and streaming exporter test doubles

## Result

- repository export no longer requires all commits to be collected before timeline building starts
- local history reading has an explicit Git CLI path with tested rename and path parsing behavior
- the project can now be packed, installed and released as a `changetrace` .NET global tool