### PR TITLE
Perf: Stream exports and optimize .gittrace serialization

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -41,3 +41,57 @@ jobs:
         with:
           configuration-path: .github/config/labeler.yml
           sync-labels: true
+
+  performance-labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply Performance label from issues or PR text
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n${pr.body || ''}`.toLowerCase();
+            const keywordMatch = /(perf|performance|benchmark|optimiz|allocation|memory pressure|throughput|latency)/i.test(text);
+            const issueNumbers = new Set();
+
+            for (const match of text.matchAll(/(?:closes|fixes|related to)\s+#(\d+)/gi)) {
+              issueNumbers.add(Number(match[1]));
+            }
+
+            for (const match of text.matchAll(/#(\d+)/g)) {
+              issueNumbers.add(Number(match[1]));
+            }
+
+            let issueMatch = false;
+
+            for (const number of issueNumbers) {
+              const issue = await github.rest.issues.get({ owner, repo, issue_number: number });
+              const labels = issue.data.labels.map(label => label.name);
+
+              if (labels.includes('Performance')) {
+                issueMatch = true;
+                break;
+              }
+            }
+
+            if (!keywordMatch && !issueMatch) {
+              core.info('Performance label not applicable for this PR.');
+              return;
+            }
+
+            const currentLabels = pr.labels.map(label => label.name);
+            if (currentLabels.includes('Performance')) {
+              core.info('Performance label already present.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr.number,
+              labels: ['Performance']
+            });
+            core.info('Performance label added.');

--- a/Benchmarks/Scenario/GIt/RepositoryExporterEndToEndBenchmarks.cs
+++ b/Benchmarks/Scenario/GIt/RepositoryExporterEndToEndBenchmarks.cs
@@ -1,0 +1,229 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Interfaces;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Results;
+using ChangeTrace.Core.Services;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Interfaces;
+using ChangeTrace.GIt.Options;
+using ChangeTrace.GIt.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ChangeTrace.Benchmarks.GIt.Benchmarks;
+
+/// <summary>
+/// Benchmarks the end-to-end local export pipeline through
+/// <see cref="RepositoryExporter.ExportAndSaveAsync"/>, including:
+/// commit streaming, timeline build, MsgPack serialization, and file persistence.
+/// </summary>
+[MemoryDiagnoser]
+[InProcess]
+[BenchmarkCategory(BenchmarkCategories.Git, BenchmarkCategories.Export, BenchmarkCategories.Serialization)]
+public class RepositoryExporterEndToEndBenchmarks
+{
+    private const int CommitCount = 1_000_000;
+    private const long BaseUnix = 1_700_000_000;
+    private static readonly int[] FilesPerCommitPattern = [3, 5, 10, 15, 25];
+    private static readonly ActorName[] Actors = CreateActors();
+    private static readonly string[] Messages = CreateMessages();
+
+    private static readonly BranchName[] Branches =
+    [
+        BranchName.Create("main").Value,
+        BranchName.Create("develop").Value,
+        BranchName.Create("feature/render").Value,
+        BranchName.Create("feature/export").Value
+    ];
+    private static readonly IReadOnlyList<BranchName>[] BranchSets = CreateBranchSets();
+    private static readonly IReadOnlyList<FileChange>[,] FileChangeSets = CreateFileChangeSets();
+
+    private static readonly ExportOptions ExportOptions = new()
+    {
+        IncludeFileChanges = true,
+        IncludeBranchEvents = true,
+        IncludeMergeDetection = true,
+        EnrichWithPullRequests = false
+    };
+
+    private ILoggerFactory _loggerFactory = null!;
+    private RepositoryExporter _exporter = null!;
+    private string _repositoryPath = null!;
+    private string _outputPath = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.None));
+
+        _repositoryPath = Directory.CreateTempSubdirectory("ChangeTrace.Benchmarks.Export.Source.").FullName;
+        _outputPath = Path.Combine(
+            Directory.CreateTempSubdirectory("ChangeTrace.Benchmarks.Export.Output.").FullName,
+            "timeline");
+
+        var serializer = new MessagePackSerializer<Timeline>(
+            [new TimelineMessagePackFormatter()]);
+        var repository = new TimelineRepositoryMsgPack(
+            _loggerFactory.CreateLogger<TimelineRepositoryMsgPack>(),
+            serializer,
+            new FileManager());
+
+        _exporter = new RepositoryExporter(
+            new GeneratedGitRepositoryReader(),
+            new TimelineBuilder(_loggerFactory.CreateLogger<TimelineBuilder>()),
+            repository,
+            _loggerFactory.CreateLogger<RepositoryExporter>());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _loggerFactory.Dispose();
+
+        if (Directory.Exists(_repositoryPath))
+            Directory.Delete(_repositoryPath, recursive: true);
+
+        var outputDirectory = Path.GetDirectoryName(_outputPath);
+        if (!string.IsNullOrEmpty(outputDirectory) && Directory.Exists(outputDirectory))
+            Directory.Delete(outputDirectory, recursive: true);
+    }
+
+    [Benchmark]
+    public async Task<long> ExportMillionCommitsToGitTrace()
+    {
+        var result = await _exporter.ExportAndSaveAsync(
+            _repositoryPath,
+            _outputPath,
+            ExportOptions);
+
+        if (result.IsFailure)
+            throw new InvalidOperationException(result.Error);
+
+        return new FileInfo(_outputPath + ".gittrace").Length;
+    }
+
+    private static ActorName[] CreateActors()
+    {
+        var actors = new ActorName[64];
+        for (var index = 0; index < actors.Length; index++)
+            actors[index] = ActorName.FromTrustedSerialized($"actor-{index}");
+
+        return actors;
+    }
+
+    private static string[] CreateMessages()
+    {
+        var messages = new string[128];
+        for (var index = 0; index < messages.Length; index++)
+            messages[index] = $"Benchmark commit bucket {index}";
+
+        return messages;
+    }
+
+    private static IReadOnlyList<BranchName>[] CreateBranchSets()
+    {
+        var branchSets = new IReadOnlyList<BranchName>[Branches.Length];
+        for (var index = 0; index < Branches.Length; index++)
+            branchSets[index] = [Branches[index]];
+
+        return branchSets;
+    }
+
+    private static IReadOnlyList<FileChange>[,] CreateFileChangeSets()
+    {
+        var fileChangeSets = new IReadOnlyList<FileChange>[128, FilesPerCommitPattern.Length];
+
+        for (var moduleIndex = 0; moduleIndex < 128; moduleIndex++)
+        {
+            for (var patternIndex = 0; patternIndex < FilesPerCommitPattern.Length; patternIndex++)
+            {
+                var filesPerCommit = FilesPerCommitPattern[patternIndex];
+                var changes = new FileChange[filesPerCommit];
+
+                for (var fileIndex = 0; fileIndex < filesPerCommit; fileIndex++)
+                {
+                    changes[fileIndex] = new FileChange(
+                        FilePath.FromTrustedSerialized(
+                            $"src/module-{moduleIndex}/feature-{fileIndex % 16}/file-slot-{fileIndex}.cs"),
+                        fileIndex % 11 == 0 ? FileChangeKind.Added : FileChangeKind.Modified);
+                }
+
+                fileChangeSets[moduleIndex, patternIndex] = changes;
+            }
+        }
+
+        return fileChangeSets;
+    }
+
+    private sealed class GeneratedGitRepositoryReader : IGitRepositoryReader
+    {
+        public Task<Result<IReadOnlyList<CommitData>>> ReadCommitsAsync(
+            string repositoryPath,
+            GitReaderOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Result<IReadOnlyList<CommitData>>.Failure(
+                "End-to-end benchmark uses streaming history only."));
+
+        public Task<Result<IAsyncEnumerable<CommitData>>> ReadCommitsStreamAsync(
+            string repositoryPath,
+            GitReaderOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Result<IAsyncEnumerable<CommitData>>.Success(
+                StreamCommits(cancellationToken)));
+        }
+
+        public Task<Result> CloneAsync(
+            string url,
+            string destinationPath,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Result.Success());
+
+        private static async IAsyncEnumerable<CommitData> StreamCommits(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            for (var index = 0; index < CommitCount; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                yield return new CommitData(
+                    Sha: CommitSha.FromTrustedSerialized(index.ToString("x40")),
+                    Author: Actors[index % Actors.Length],
+                    Timestamp: Timestamp.FromTrustedUnixSeconds(BaseUnix + index),
+                    Message: Messages[index % Messages.Length],
+                    ParentShas: CreateParentShas(index),
+                    FileChanges: CreateFileChanges(index),
+                    Branches: BranchSets[index % BranchSets.Length],
+                    IsMerge: index > 0 && index % 50 == 0);
+            }
+        }
+
+        private static IReadOnlyList<CommitSha> CreateParentShas(int index)
+        {
+            if (index == 0)
+                return [];
+
+            if (index > 1 && index % 50 == 0)
+            {
+                return
+                [
+                    CommitSha.FromTrustedSerialized((index - 1).ToString("x40")),
+                    CommitSha.FromTrustedSerialized(Math.Max(0, index - 17).ToString("x40"))
+                ];
+            }
+
+            return
+            [
+                CommitSha.FromTrustedSerialized((index - 1).ToString("x40"))
+            ];
+        }
+
+        private static IReadOnlyList<FileChange> CreateFileChanges(int commitIndex)
+        {
+            var moduleIndex = commitIndex % 128;
+            var filesPerCommit = FilesPerCommitPattern[commitIndex % FilesPerCommitPattern.Length];
+            var patternIndex = Array.IndexOf(FilesPerCommitPattern, filesPerCommit);
+            return FileChangeSets[moduleIndex, patternIndex];
+        }
+    }
+}

--- a/Benchmarks/Subsystem/Core/TimelineBuilderBenchmarks.cs
+++ b/Benchmarks/Subsystem/Core/TimelineBuilderBenchmarks.cs
@@ -5,7 +5,7 @@ using ChangeTrace.Core.Options;
 using ChangeTrace.Core.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace ChangeTrace.Benchmarks.Core.Benchmarks;
+namespace ChangeTrace.Benchmarks.Subsystem.Core;
 
 /// <summary>
 /// Benchmarks timeline construction from already-read commit data.
@@ -54,14 +54,36 @@ public class TimelineBuilderBenchmarks
     }
 
     [Benchmark(Baseline = true)]
-    public int BuildWithCommitsOnly()
-        => _builder.Build(_commits, CommitsOnlyOptions).Value.Count;
+    public async Task<int> BuildWithCommitsOnly()
+        => (await _builder.Build(ToAsyncEnumerable(_commits), CommitsOnlyOptions)).Value.Count;
 
     [Benchmark]
-    public int BuildWithFileChanges()
-        => _builder.Build(_commits, FileChangesOptions).Value.Count;
+    public async Task<int> BuildWithFileChanges()
+        => (await _builder.Build(ToAsyncEnumerable(_commits), FileChangesOptions)).Value.Count;
 
     [Benchmark]
-    public int BuildWithAllEvents()
-        => _builder.Build(_commits, AllEventsOptions).Value.Count;
+    public async Task<int> BuildWithAllEvents()
+        => (await _builder.Build(ToAsyncEnumerable(_commits), AllEventsOptions)).Value.Count;
+
+    private static IAsyncEnumerable<CommitData> ToAsyncEnumerable(IEnumerable<CommitData> commits)
+        => new AsyncEnumerableAdapter(commits);
+
+    private sealed class AsyncEnumerableAdapter(IEnumerable<CommitData> commits) : IAsyncEnumerable<CommitData>
+    {
+        public IAsyncEnumerator<CommitData> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => new AsyncEnumerator(commits.GetEnumerator());
+
+        private sealed class AsyncEnumerator(IEnumerator<CommitData> enumerator) : IAsyncEnumerator<CommitData>
+        {
+            public CommitData Current => enumerator.Current;
+
+            public ValueTask<bool> MoveNextAsync() => new(enumerator.MoveNext());
+
+            public ValueTask DisposeAsync()
+            {
+                enumerator.Dispose();
+                return default;
+            }
+        }
+    }
 }

--- a/Benchmarks/Subsystem/GIt/TimelineRepositoryMsgPackBenchmarks.cs
+++ b/Benchmarks/Subsystem/GIt/TimelineRepositoryMsgPackBenchmarks.cs
@@ -1,0 +1,88 @@
+using BenchmarkDotNet.Attributes;
+using ChangeTrace.Benchmarks.Core.Fixtures;
+using ChangeTrace.Core.Services;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ChangeTrace.Benchmarks.GIt.Benchmarks;
+
+/// <summary>
+/// Benchmarks full .gittrace persistence through <see cref="TimelineRepositoryMsgPack"/>,
+/// including serializer and file I/O.
+/// </summary>
+[MemoryDiagnoser]
+[InProcess]
+[MinIterationTime(250)]
+[BenchmarkCategory(BenchmarkCategories.Git, BenchmarkCategories.Serialization)]
+public class TimelineRepositoryMsgPackBenchmarks
+{
+    private ILoggerFactory _loggerFactory = null!;
+    private TimelineRepositoryMsgPack _repository = null!;
+    private Timeline _timeline = null!;
+    private string _directoryPath = null!;
+    private string _timelinePath = null!;
+
+    [Params(1_000, 10_000, 100_000)]
+    public int CommitCount { get; set; }
+
+    [Params(4, 12)]
+    public int FilesPerCommit { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.None));
+
+        var serializer = new MessagePackSerializer<Timeline>(
+            [new TimelineMessagePackFormatter()]);
+        var fileManager = new FileManager();
+
+        _repository = new TimelineRepositoryMsgPack(
+            _loggerFactory.CreateLogger<TimelineRepositoryMsgPack>(),
+            serializer,
+            fileManager);
+
+        _timeline = TimelineBenchmarkFixture.Create(
+            CommitCount,
+            FilesPerCommit).Timeline;
+
+        _directoryPath = Directory.CreateTempSubdirectory("ChangeTrace.Benchmarks.TimelineRepository.").FullName;
+        _timelinePath = Path.Combine(_directoryPath, "timeline");
+
+        var saveResult = await _repository.SaveAsync(_timeline, _timelinePath);
+        if (saveResult.IsFailure)
+            throw new InvalidOperationException(saveResult.Error);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _loggerFactory.Dispose();
+
+        if (Directory.Exists(_directoryPath))
+            Directory.Delete(_directoryPath, recursive: true);
+    }
+
+    [Benchmark]
+    public async Task<int> SaveTimeline()
+    {
+        var result = await _repository.SaveAsync(_timeline, _timelinePath);
+        if (result.IsFailure)
+            throw new InvalidOperationException(result.Error);
+
+        return new FileInfo(_timelinePath + ".gittrace").Length > int.MaxValue
+            ? int.MaxValue
+            : (int)new FileInfo(_timelinePath + ".gittrace").Length;
+    }
+
+    [Benchmark]
+    public async Task<int> LoadTimeline()
+    {
+        var result = await _repository.LoadAsync(_timelinePath + ".gittrace");
+        if (result.IsFailure)
+            throw new InvalidOperationException(result.Error);
+
+        return result.Value.Count;
+    }
+}

--- a/Tests/Unit/Core/Serialization/GenericTimelineSerializerTests.cs
+++ b/Tests/Unit/Core/Serialization/GenericTimelineSerializerTests.cs
@@ -47,6 +47,31 @@ public sealed class GenericTimelineSerializerTests
         AssertTimeline(deserialized);
     }
 
+    /// <summary>RoundTrip preserves pull request metadata attached to a timeline event.</summary>
+    [Fact]
+    public async Task RoundTrip_PreservesPullRequestMetadata()
+    {
+        var serializer = new MessagePackSerializer<Timeline>(
+            [new TimelineMessagePackFormatter()]);
+
+        var timeline = new Timeline(RepositoryId.Create("rian-be", "ChangeTrace").Value);
+        var commit = TraceEventFactory.Commit(
+            Timestamp.Create(1_735_689_600).Value,
+            ActorName.Create("rian").Value,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "Update timeline")
+            .WithPullRequest(
+                PullRequestNumber.Create(27).Value,
+                PullRequestEventType.PullRequestMerged);
+        timeline.AddEvent(commit);
+
+        var bytes = await serializer.SerializeAsync(timeline);
+        var deserialized = await serializer.DeserializeAsync(bytes);
+
+        Assert.Equal(27, deserialized.Events[0].PullRequest?.Number.Value);
+        Assert.Equal(PullRequestEventType.PullRequestMerged, deserialized.Events[0].PullRequest?.Type);
+    }
+
     /// <summary>Creates a timeline containing one file-change event for serializer assertions.</summary>
     private static Timeline CreateTimeline()
     {

--- a/Tests/Unit/CredentialTrace/Services/WorkspaceContextFileStoreTests.cs
+++ b/Tests/Unit/CredentialTrace/Services/WorkspaceContextFileStoreTests.cs
@@ -82,6 +82,20 @@ public sealed class WorkspaceContextFileStoreTests
             return Task.FromResult(BytesToLoad);
         }
 
+        public Task<Stream> OpenWriteAsync(string path, CancellationToken cancellationToken = default)
+        {
+            SavedPath = path;
+            Stream stream = new MemoryStream();
+            return Task.FromResult(stream);
+        }
+
+        public Task<Stream> OpenReadAsync(string path, CancellationToken cancellationToken = default)
+        {
+            LoadedPath = path;
+            Stream stream = new MemoryStream(BytesToLoad, writable: false);
+            return Task.FromResult(stream);
+        }
+
         /// <summary>Returns true only for configured existing path.</summary>
         public bool Exists(string path) => path == ExistingPath;
 

--- a/Tests/Unit/GIt/RepositoryExporterTests.cs
+++ b/Tests/Unit/GIt/RepositoryExporterTests.cs
@@ -329,7 +329,7 @@ public sealed class RepositoryExporterTests
             return Result<Timeline>.Success(TimelineToReturn);
         }
 
-        public async Task<Result<Timeline>> BuildAsync(
+        public async Task<Result<Timeline>> Build(
             IAsyncEnumerable<CommitData> commits,
             TimelineBuilderOptions options,
             CancellationToken cancellationToken = default)

--- a/Tests/Unit/GIt/TimelineRepositoryMsgPackTests.cs
+++ b/Tests/Unit/GIt/TimelineRepositoryMsgPackTests.cs
@@ -135,6 +135,22 @@ public sealed class TimelineRepositoryMsgPackTests
             return Task.FromResult(BytesToLoad);
         }
 
+        public Task<Stream> OpenWriteAsync(string path, CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            SavedPath = path;
+
+            Stream stream = new RecordingMemoryStream(bytes => SavedBytes = bytes);
+            return Task.FromResult(stream);
+        }
+
+        public Task<Stream> OpenReadAsync(string path, CancellationToken cancellationToken = default)
+        {
+            LoadedPath = path;
+            Stream stream = new MemoryStream(BytesToLoad, writable: false);
+            return Task.FromResult(stream);
+        }
+
         /// <summary>Returns whether a file exists on disk.</summary>
         public bool Exists(string path) => File.Exists(path);
 
@@ -148,5 +164,16 @@ public sealed class TimelineRepositoryMsgPackTests
 
         /// <summary>Returns no files for tests that do not cover file discovery.</summary>
         public IEnumerable<string> FindFiles(string directory, string extension) => [];
+
+        private sealed class RecordingMemoryStream(Action<byte[]> onDispose) : MemoryStream
+        {
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                    onDispose(ToArray());
+
+                base.Dispose(disposing);
+            }
+        }
     }
 }

--- a/src/Cli/Commands/Debug/TimelineLoaderDebug.cs
+++ b/src/Cli/Commands/Debug/TimelineLoaderDebug.cs
@@ -1,5 +1,6 @@
 using ChangeTrace.Core.Interfaces;
 using ChangeTrace.Core.Timelines;
+using ChangeTrace.Cli.Services;
 
 namespace ChangeTrace.Cli.Commands.Debug;
 
@@ -22,9 +23,7 @@ internal static class TimelineLoader
 
         try
         {
-            var data = await File.ReadAllBytesAsync(filePath, ct);
-            var timeline = await serializer.DeserializeAsync(data, ct);
-            return timeline;
+            return await TimelineFileLoader.LoadAsync(serializer, filePath, ct);
         }
         catch (Exception ex)
         {

--- a/src/Cli/Handlers/Debug/WindowDebugCommandHandler.cs
+++ b/src/Cli/Handlers/Debug/WindowDebugCommandHandler.cs
@@ -7,6 +7,7 @@ using ChangeTrace.Core.Timelines;
 using ChangeTrace.Graphics.Window;
 using ChangeTrace.Player.Factory;
 using ChangeTrace.Rendering.Factory;
+using ChangeTrace.Cli.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ChangeTrace.Cli.Handlers.Debug;
@@ -24,7 +25,7 @@ internal sealed class WindowDebugCommandHandler(
     /// <summary>
     /// Loads timeline files and starts player windows with debug diagnostics.
     /// </summary>
-    public Task HandleAsync(
+    public async Task HandleAsync(
         ParseResult parseResult,
         CancellationToken ct)
     {
@@ -33,22 +34,18 @@ internal sealed class WindowDebugCommandHandler(
         if (!File.Exists(filePath))
         {
             Console.WriteLine($"[red]File not found: {filePath}[/]");
-            return Task.CompletedTask;
+            return;
         }
 
         try
         {
             Console.WriteLine($"[cyan]Loading timeline from: {filePath}[/]");
 
-            var data = File.ReadAllBytes(filePath);
+            var fileSize = new FileInfo(filePath).Length;
 
-            Console.WriteLine($"[cyan]File size: {data.Length} bytes[/]");
+            Console.WriteLine($"[cyan]File size: {fileSize} bytes[/]");
 
-            var timeline =
-                serializer
-                    .DeserializeAsync(data, ct)
-                    .GetAwaiter()
-                    .GetResult();
+            var timeline = await TimelineFileLoader.LoadAsync(serializer, filePath, ct);
 
             Console.WriteLine($"[green]Timeline loaded: {timeline.Events.Count} events[/]");
 
@@ -70,13 +67,11 @@ internal sealed class WindowDebugCommandHandler(
             Console.WriteLine(ex.StackTrace);
 
             if (ex.InnerException is null)
-                return Task.CompletedTask;
+                return;
 
             Console.WriteLine($"[red]Inner exception: {ex.InnerException.Message}[/]");
             Console.WriteLine("[red]Inner stack trace:[/]");
             Console.WriteLine(ex.InnerException.StackTrace);
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Cli/Handlers/Profiles/Workspaces/WorkPlayCommandHandler.cs
+++ b/src/Cli/Handlers/Profiles/Workspaces/WorkPlayCommandHandler.cs
@@ -9,6 +9,7 @@ using ChangeTrace.CredentialTrace.Profiles;
 using ChangeTrace.Graphics.Window;
 using ChangeTrace.Player.Factory;
 using ChangeTrace.Rendering.Factory;
+using ChangeTrace.Cli.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 
@@ -132,8 +133,7 @@ internal sealed class WorkPlayCommandHandler(
 
         AnsiConsole.MarkupLine($"[green]Playing[/] {Markup.Escape(selected.Path)}");
 
-        var data = await File.ReadAllBytesAsync(selected.Path, ct);
-        var timeline = await serializer.DeserializeAsync(data, ct);
+        var timeline = await TimelineFileLoader.LoadAsync(serializer, selected.Path, ct);
         var player = playerFactory.Create(timeline, initialSpeed: 1.5, acceleration: 2.5);
 
         using var debugWindow = new DebugWindow(diagnostics);

--- a/src/Cli/Handlers/ShowTimelineCommandHandler.cs
+++ b/src/Cli/Handlers/ShowTimelineCommandHandler.cs
@@ -7,6 +7,7 @@ using ChangeTrace.Core.Timelines;
 using ChangeTrace.Graphics.Window;
 using ChangeTrace.Player.Factory;
 using ChangeTrace.Rendering.Factory;
+using ChangeTrace.Cli.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 
@@ -37,8 +38,7 @@ internal sealed class ShowTimelineCommandHandler(
 
         AnsiConsole.MarkupLine($"[green]Playing[/] {Markup.Escape(filePath)}");
 
-        var data = await File.ReadAllBytesAsync(filePath, ct);
-        var timeline = await serializer.DeserializeAsync(data, ct);
+        var timeline = await TimelineFileLoader.LoadAsync(serializer, filePath, ct);
         var player = playerFactory.Create(timeline, initialSpeed: 1.5, acceleration: 2.5);
 
         using var debugWindow = new DebugWindow(diagnostics);

--- a/src/Cli/Services/TimelineFileLoader.cs
+++ b/src/Cli/Services/TimelineFileLoader.cs
@@ -1,0 +1,35 @@
+using ChangeTrace.Core.Interfaces;
+using ChangeTrace.Core.Timelines;
+
+namespace ChangeTrace.Cli.Services;
+
+/// <summary>
+/// Loads serialized timeline files without materializing the full trace as a byte array when stream support is available.
+/// </summary>
+internal static class TimelineFileLoader
+{
+    /// <summary>
+    /// Loads and deserializes a timeline from disk.
+    /// </summary>
+    public static async Task<Timeline> LoadAsync(
+        ISerializer<Timeline> serializer,
+        string filePath,
+        CancellationToken ct = default)
+    {
+        if (serializer is IStreamingSerializer<Timeline> streamingSerializer)
+        {
+            await using var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 131072,
+                options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            return await streamingSerializer.DeserializeAsync(stream, ct);
+        }
+
+        var data = await File.ReadAllBytesAsync(filePath, ct);
+        return await serializer.DeserializeAsync(data, ct);
+    }
+}

--- a/src/Core/Interfaces/IFileManager.cs
+++ b/src/Core/Interfaces/IFileManager.cs
@@ -25,6 +25,17 @@ internal interface IFileManager
     Task<byte[]> LoadAsync(string path, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Opens a writable stream for the specified path.
+    /// Ensures parent directories exist before opening the stream.
+    /// </summary>
+    Task<Stream> OpenWriteAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens a readable stream for the specified path.
+    /// </summary>
+    Task<Stream> OpenReadAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks if file exists at path.
     /// </summary>
     /// <param name="path">File path to check.</param>

--- a/src/Core/Interfaces/IStreamingSerializer.cs
+++ b/src/Core/Interfaces/IStreamingSerializer.cs
@@ -1,0 +1,17 @@
+namespace ChangeTrace.Core.Interfaces;
+
+/// <summary>
+/// Optional serializer extension for stream-based serialization and deserialization.
+/// </summary>
+internal interface IStreamingSerializer<T>
+{
+    /// <summary>
+    /// Serializes the given object directly into the destination stream.
+    /// </summary>
+    Task SerializeAsync(Stream destination, T obj, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deserializes an object directly from the source stream.
+    /// </summary>
+    Task<T> DeserializeAsync(Stream source, CancellationToken ct = default);
+}

--- a/src/Core/Models/ActorName.cs
+++ b/src/Core/Models/ActorName.cs
@@ -30,6 +30,9 @@ internal sealed record ActorName : ValueObject
             ? Result<ActorName>.Failure("Actor name too long")
             : Result<ActorName>.Success(new ActorName(value));
     }
+
+    internal static ActorName FromTrustedSerialized(string value)
+        => new(value);
     
     public override string ToString() => Value;
     public static implicit operator string(ActorName actor) => actor.Value;

--- a/src/Core/Models/BranchName.cs
+++ b/src/Core/Models/BranchName.cs
@@ -50,6 +50,9 @@ internal sealed record BranchName : ValueObject
         return Result<BranchName>.Success(new BranchName(value));
     }
 
+    internal static BranchName FromTrustedSerialized(string value)
+        => new(value);
+
     public override string ToString() => Value;
     public static implicit operator string(BranchName branch) => branch.Value;
 }

--- a/src/Core/Models/CommitSha.cs
+++ b/src/Core/Models/CommitSha.cs
@@ -42,6 +42,9 @@ internal sealed partial record CommitSha : ValueObject
             : Result<CommitSha>.Success(new CommitSha(value));
     }
 
+    internal static CommitSha FromTrustedSerialized(string value)
+        => new(value);
+
     /// <summary>
     /// Checks whether this SHA matches another SHA, supporting partial matching.
     /// Compares up to the length of the shorter SHA.

--- a/src/Core/Models/FilePath.cs
+++ b/src/Core/Models/FilePath.cs
@@ -41,6 +41,9 @@ internal sealed record FilePath : ValueObject
         return Result<FilePath>.Success(new FilePath(value));
     }
 
+    internal static FilePath FromTrustedSerialized(string value)
+        => new(value);
+
     /// <summary>
     /// Checks whether this file path is inside the specified directory.
     /// </summary>

--- a/src/Core/Models/RepositoryId.cs
+++ b/src/Core/Models/RepositoryId.cs
@@ -55,5 +55,8 @@ internal sealed record RepositoryId : ValueObject
         return Create(parts[0], parts[1]);
     }
 
+    internal static RepositoryId FromTrustedSerialized(string owner, string name)
+        => new(owner, name);
+
     public override string ToString() => FullName;
 }

--- a/src/Core/Models/Timestamp.cs
+++ b/src/Core/Models/Timestamp.cs
@@ -47,6 +47,9 @@ internal readonly struct Timestamp : IComparable<Timestamp>
             : Result<Timestamp>.Success(new Timestamp(unixSeconds));
     }
 
+    internal static Timestamp FromTrustedUnixSeconds(long unixSeconds)
+        => new(unixSeconds);
+
     /// <summary>
     /// Current UTC timestamp.
     /// </summary>

--- a/src/Core/Services/FileManager.cs
+++ b/src/Core/Services/FileManager.cs
@@ -38,6 +38,42 @@ internal sealed class FileManager : IFileManager
         => File.ReadAllBytesAsync(path, cancellationToken);
 
     /// <summary>
+    /// Opens a writable file stream and ensures the target directory exists first.
+    /// </summary>
+    public Task<Stream> OpenWriteAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        Stream stream = new FileStream(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 131072,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        return Task.FromResult(stream);
+    }
+
+    /// <summary>
+    /// Opens a readable file stream for sequential reads.
+    /// </summary>
+    public Task<Stream> OpenReadAsync(string path, CancellationToken cancellationToken = default)
+    {
+        Stream stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 131072,
+            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        return Task.FromResult(stream);
+    }
+
+    /// <summary>
     /// Checks if file exists at path.
     /// </summary>
     /// <param name="path">File path to check.</param>

--- a/src/Core/Services/MessagePackSerializer.cs
+++ b/src/Core/Services/MessagePackSerializer.cs
@@ -21,7 +21,7 @@ namespace ChangeTrace.Core.Services;
 /// </list>
 /// </remarks>
 [AutoRegister(ServiceLifetime.Singleton)]
-internal sealed class MessagePackSerializer<T> : ISerializer<T>
+internal sealed class MessagePackSerializer<T> : ISerializer<T>, IStreamingSerializer<T>
 {
     private readonly MessagePackSerializerOptions _options;
 
@@ -46,11 +46,10 @@ internal sealed class MessagePackSerializer<T> : ISerializer<T>
     /// <param name="obj">Object to serialize.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Byte array representing serialized object.</returns>
-    public async Task<byte[]> SerializeAsync(T obj, CancellationToken ct = default)
+    public Task<byte[]> SerializeAsync(T obj, CancellationToken ct = default)
     {
-        await using var ms = new MemoryStream();
-        await MessagePackSerializer.SerializeAsync(ms, obj, _options, ct);
-        return ms.ToArray();
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(MessagePackSerializer.Serialize(obj, _options));
     }
 
     /// <summary>
@@ -59,9 +58,27 @@ internal sealed class MessagePackSerializer<T> : ISerializer<T>
     /// <param name="data">Byte array to deserialize.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Deserialized object of type <typeparamref name="T"/>.</returns>
-    public async Task<T> DeserializeAsync(byte[] data, CancellationToken ct = default)
+    public Task<T> DeserializeAsync(byte[] data, CancellationToken ct = default)
     {
-        await using var ms = new MemoryStream(data);
-        return await MessagePackSerializer.DeserializeAsync<T>(ms, _options, ct);
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(MessagePackSerializer.Deserialize<T>(data, _options));
+    }
+
+    /// <summary>
+    /// Serializes an object directly into a stream.
+    /// </summary>
+    public async Task SerializeAsync(Stream destination, T obj, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        await MessagePackSerializer.SerializeAsync(destination, obj, _options, ct);
+    }
+
+    /// <summary>
+    /// Deserializes an object directly from a stream.
+    /// </summary>
+    public async Task<T> DeserializeAsync(Stream source, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return await MessagePackSerializer.DeserializeAsync<T>(source, _options, ct);
     }
 }

--- a/src/Core/Services/TimelineBuilder.cs
+++ b/src/Core/Services/TimelineBuilder.cs
@@ -1,6 +1,4 @@
 using ChangeTrace.Configuration.Discovery;
-using ChangeTrace.Core.Enums;
-using ChangeTrace.Core.Events;
 using ChangeTrace.Core.Models;
 using ChangeTrace.Core.Options;
 using ChangeTrace.Core.Results;
@@ -12,46 +10,16 @@ using Microsoft.Extensions.Logging;
 namespace ChangeTrace.Core.Services;
 
 /// <summary>
-/// Builds a timeline from raw commit data.
-/// Transforms low level Git commit information into a structured timeline of events
-/// (commits, file changes, branch operations, merges) based on configuration options.
-/// Focuses on performance and clarity with minimal allocations.
+/// Builds timeline from commit data.
+/// Handles commit, file change, branch and merge event emission.
 /// </summary>
 [AutoRegister(ServiceLifetime.Singleton)]
 internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimelineBuilder
 {
     /// <summary>
-    /// Builds a timeline from a collection of commits.
+    /// Builds timeline from an asynchronous commit stream.
     /// </summary>
-    /// <param name="commits">The raw commit data to process.</param>
-    /// <param name="options">Configuration options controlling which events are generated.</param>
-    /// <returns>
-    /// A <see cref="Result{Timeline}"/> containing the constructed timeline with all requested events,
-    /// or failure with error details if building fails.
-    /// </returns>
-    public Result<Timeline> Build(
-        IReadOnlyList<CommitData> commits,
-        TimelineBuilderOptions options)
-    {
-        try
-        {
-            logger.LogInformation("Building timeline from {Count} commits", commits.Count);
-
-            var timeline = new Timeline(
-                options.RepositoryId,
-                EstimateInitialCapacity(commits, options));
-            BuildCore(timeline, commits, options);
-            
-            return Result<Timeline>.Success(timeline);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to build timeline");
-            return Result<Timeline>.Failure("Failed to build timeline", ex);
-        }
-    }
-
-    public async Task<Result<Timeline>> BuildAsync(
+    public async Task<Result<Timeline>> Build(
         IAsyncEnumerable<CommitData> commits,
         TimelineBuilderOptions options,
         CancellationToken cancellationToken = default)
@@ -61,7 +29,7 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
             logger.LogInformation("Building timeline from commit stream");
 
             var timeline = new Timeline(options.RepositoryId);
-            var count = await BuildCoreAsync(timeline, commits, options, cancellationToken);
+            var count = await BuildCore(timeline, commits, options, cancellationToken);
 
             logger.LogInformation("Built timeline from {Count} streamed commits", count);
             return Result<Timeline>.Success(timeline);
@@ -73,40 +41,7 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
         }
     }
 
-    private static void BuildCore(
-        Timeline timeline,
-        IReadOnlyList<CommitData> commits,
-        TimelineBuilderOptions options)
-    {
-        if (!options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection)
-        {
-            for (var index = 0; index < commits.Count; index++)
-                AddCommitEvent(timeline, commits[index]);
-
-            return;
-        }
-
-        if (options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection)
-        {
-            for (var index = 0; index < commits.Count; index++)
-            {
-                var commit = commits[index];
-                AddCommitEvent(timeline, commit);
-                AddFileChangeEvents(timeline, commit);
-            }
-
-            return;
-        }
-
-        var branchTracker = options.IncludeBranchEvents
-            ? new BranchTracker()
-            : null;
-
-        for (var index = 0; index < commits.Count; index++)
-            AddCommitToTimeline(timeline, commits[index], options, branchTracker);
-    }
-
-    private async Task<int> BuildCoreAsync(
+    private async Task<int> BuildCore(
         Timeline timeline,
         IAsyncEnumerable<CommitData> commits,
         TimelineBuilderOptions options,
@@ -114,26 +49,24 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
     {
         var count = 0;
 
-        if (!options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection)
+        if (IsCommitOnly(options))
         {
             await foreach (var commit in commits.WithCancellation(cancellationToken))
             {
-                AddCommitEvent(timeline, commit);
+                TimelineEventEmitter.EmitCommit(commit, timeline.AddEvent);
                 count++;
-                LogProgress(count);
             }
 
             return count;
         }
 
-        if (options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection)
+        if (IsCommitAndFileChangesOnly(options))
         {
             await foreach (var commit in commits.WithCancellation(cancellationToken))
             {
-                AddCommitEvent(timeline, commit);
-                AddFileChangeEvents(timeline, commit);
+                TimelineEventEmitter.EmitCommit(commit, timeline.AddEvent);
+                TimelineEventEmitter.EmitFileChanges(commit, timeline.AddEvent);
                 count++;
-                LogProgress(count);
             }
 
             return count;
@@ -147,17 +80,16 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
         {
             AddCommitToTimeline(timeline, commit, options, branchTracker);
             count++;
-            LogProgress(count);
         }
 
         return count;
     }
 
-    private void LogProgress(int count)
-    {
-        if (count % 50000 == 0)
-            logger.LogInformation("Processed {Count} commits...", count);
-    }
+    private static bool IsCommitOnly(TimelineBuilderOptions options)
+        => !options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection;
+
+    private static bool IsCommitAndFileChangesOnly(TimelineBuilderOptions options)
+        => options.IncludeFileChanges && !options.IncludeBranchEvents && !options.IncludeMergeDetection;
 
     private static void AddCommitToTimeline(
         Timeline timeline,
@@ -165,175 +97,10 @@ internal sealed class TimelineBuilder(ILogger<TimelineBuilder> logger) : ITimeli
         TimelineBuilderOptions options,
         BranchTracker? branchTracker)
     {
-        AddCommitEvent(timeline, commit);
-        if (options.IncludeFileChanges)
-        {
-            AddFileChangeEvents(timeline, commit);
-        }
-        if (options.IncludeBranchEvents && branchTracker is not null)
-        {
-            AddBranchEvents(timeline, commit, branchTracker);
-        }
-        if (options.IncludeMergeDetection && commit.IsMerge)
-        {
-            AddMergeEvent(timeline, commit);
-        }
-    }
-    
-    private static void AddCommitEvent(Timeline timeline, CommitData commit)
-    {
-        var evt = TraceEventFactory.Commit(
-            timestamp: commit.Timestamp,
-            actor: commit.Author,
-            sha: commit.Sha,
-            message: commit.Message
-        );
-
-        timeline.AddEvent(evt);
-    }
-    
-    private static void AddFileChangeEvents(Timeline timeline, CommitData commit)
-    {
-        var timestamp = commit.Timestamp;
-        var author = commit.Author;
-        var sha = commit.Sha;
-
-        foreach (var change in commit.FileChanges)
-        {
-            var evt = TraceEventFactory.FileChange(
-                timestamp: timestamp,
-                actor: author,
-                path: change.Path,
-                type: change.Kind,
-                sha: sha,
-                metadata: change.OldPath?.Value
-            );
-
-            timeline.AddEvent(evt);
-        }
-    }
-    
-    private static void AddBranchEvents(
-        Timeline timeline,
-        CommitData commit,
-        BranchTracker tracker)
-    {
-        var timestamp = commit.Timestamp;
-        var author = commit.Author;
-        var sha = commit.Sha;
-        var branches = commit.Branches;
-
-        for (int index = 0; index < branches.Count; index++)
-        {
-            var branch = branches[index];
-            bool isNew = tracker.TryUpdate(branch.Value, sha, timestamp);
-            if (!isNew)
-                continue;
-
-            var evt = TraceEventFactory.Branch(
-                timestamp: timestamp,
-                actor: author,
-                branch: branch,
-                type: BranchEventType.BranchCreated,
-                sha: sha,
-                metadata: $"Created at {sha.Short}"
-            );
-
-            timeline.AddEvent(evt);
-        }
-
-        using var pooled = tracker.GetDeletedPooled(branches);
-        var deleted = pooled.Span;
-
-        for (int index = 0; index < deleted.Length; index++)
-        {
-            var (branchName, lastSha, lastTimestamp) = deleted[index];
-            var branchNameResult = BranchName.Create(branchName);
-            if (!branchNameResult.IsSuccess)
-                continue;
-
-            var evt = TraceEventFactory.Branch(
-                timestamp: lastTimestamp,
-                actor: author,
-                branch: branchNameResult.Value,
-                type: BranchEventType.BranchDeleted,
-                sha: lastSha,
-                metadata: $"Deleted (last: {lastSha.Short})"
-            );
-
-            timeline.AddEvent(evt);
-        }
-    }
-    
-    private static void AddMergeEvent(Timeline timeline, CommitData commit)
-    {
-        var parentShas = BuildParentSummary(commit.ParentShas);
-        var metadata = string.Concat(commit.Message, " | Parents: ", parentShas);
-
-        var branch = commit.Branches.FirstOrDefault()
-                     ?? BranchName.Create("unknown").Value;
-
-        var evt = TraceEventFactory.Merge(
-            timestamp: commit.Timestamp,
-            actor: commit.Author,
-            sha: commit.Sha,
-            target: branch,
-            message: metadata
-        );
-
-        timeline.AddEvent(evt);
-    }
-
-    private static string BuildParentSummary(IReadOnlyList<CommitSha> parentShas)
-    {
-        if (parentShas.Count == 0)
-            return string.Empty;
-
-        if (parentShas.Count == 1)
-            return parentShas[0].Short;
-
-        var builder = new System.Text.StringBuilder(parentShas.Count * 10);
-
-        for (var index = 0; index < parentShas.Count; index++)
-        {
-            if (index > 0)
-                builder.Append(", ");
-
-            builder.Append(parentShas[index].Short);
-        }
-
-        return builder.ToString();
-    }
-
-    private static int EstimateInitialCapacity(
-        IReadOnlyList<CommitData> commits,
-        TimelineBuilderOptions options)
-    {
-        long capacity = commits.Count;
-
-        if (options.IncludeFileChanges)
-        {
-            for (int index = 0; index < commits.Count; index++)
-                capacity += commits[index].FileChanges.Count;
-        }
-
-        if (options.IncludeBranchEvents)
-        {
-            for (int index = 0; index < commits.Count; index++)
-                capacity += commits[index].Branches.Count * 2L;
-        }
-
-        if (options.IncludeMergeDetection)
-        {
-            for (int index = 0; index < commits.Count; index++)
-            {
-                if (commits[index].IsMerge)
-                    capacity++;
-            }
-        }
-
-        return capacity >= int.MaxValue
-            ? int.MaxValue
-            : (int)capacity;
+        TimelineEventEmitter.EmitCommitEvents(
+            commit,
+            options,
+            branchTracker,
+            timeline.AddEvent);
     }
 }

--- a/src/Core/Services/TimelineEventEmitter.cs
+++ b/src/Core/Services/TimelineEventEmitter.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Options;
+
+namespace ChangeTrace.Core.Services;
+
+/// <summary>
+/// Shared event emission logic used by both in-memory timeline building and stream-based persistence.
+/// </summary>
+internal static class TimelineEventEmitter
+{
+    /// <summary>
+    /// Emits a single commit event into the provided sink.
+    /// </summary>
+    internal static void EmitCommit(
+        CommitData commit,
+        Action<TraceEvent> sink)
+    {
+        sink(TraceEventFactory.Commit(
+            timestamp: commit.Timestamp,
+            actor: commit.Author,
+            sha: commit.Sha,
+            message: commit.Message));
+    }
+
+    /// <summary>
+    /// Emits file change events for a commit into the provided sink.
+    /// </summary>
+    internal static void EmitFileChanges(
+        CommitData commit,
+        Action<TraceEvent> sink)
+    {
+        var timestamp = commit.Timestamp;
+        var author = commit.Author;
+        var sha = commit.Sha;
+
+        foreach (var change in commit.FileChanges)
+        {
+            sink(TraceEventFactory.FileChange(
+                timestamp: timestamp,
+                actor: author,
+                path: change.Path,
+                type: change.Kind,
+                sha: sha,
+                metadata: change.OldPath?.Value));
+        }
+    }
+
+    /// <summary>
+    /// Emits branch creation and deletion events for a commit into the provided sink.
+    /// </summary>
+    internal static void EmitBranchEvents(
+        CommitData commit,
+        BranchTracker tracker,
+        Action<TraceEvent> sink)
+    {
+        var timestamp = commit.Timestamp;
+        var author = commit.Author;
+        var sha = commit.Sha;
+        var branches = commit.Branches;
+
+        foreach (var branch in branches)
+        {
+            bool isNew = tracker.TryUpdate(branch.Value, sha, timestamp);
+            if (!isNew)
+                continue;
+
+            sink(TraceEventFactory.Branch(
+                timestamp: timestamp,
+                actor: author,
+                branch: branch,
+                type: BranchEventType.BranchCreated,
+                sha: sha,
+                metadata: $"Created at {sha.Short}"));
+        }
+
+        using var pooled = tracker.GetDeletedPooled(branches);
+        var deleted = pooled.Span;
+
+        foreach (var (branchName, lastSha, lastTimestamp) in deleted)
+        {
+            var branchNameResult = BranchName.Create(branchName);
+            if (!branchNameResult.IsSuccess)
+                continue;
+
+            sink(TraceEventFactory.Branch(
+                timestamp: lastTimestamp,
+                actor: author,
+                branch: branchNameResult.Value,
+                type: BranchEventType.BranchDeleted,
+                sha: lastSha,
+                metadata: $"Deleted (last: {lastSha.Short})"));
+        }
+    }
+
+    /// <summary>
+    /// Emits a merge event for the specified commit.
+    /// </summary>
+    internal static void EmitMergeEvent(
+        CommitData commit,
+        Action<TraceEvent> sink)
+    {
+        var parentShas = BuildParentSummary(commit.ParentShas);
+        var metadata = string.Concat(commit.Message, " | Parents: ", parentShas);
+
+        var branch = commit.Branches.FirstOrDefault()
+                     ?? BranchName.Create("unknown").Value;
+
+        sink(TraceEventFactory.Merge(
+            timestamp: commit.Timestamp,
+            actor: commit.Author,
+            sha: commit.Sha,
+            target: branch,
+            message: metadata));
+    }
+
+    /// <summary>
+    /// Emits all timeline events requested by the provided options.
+    /// </summary>
+    internal static void EmitCommitEvents(
+        CommitData commit,
+        TimelineBuilderOptions options,
+        BranchTracker? branchTracker,
+        Action<TraceEvent> sink)
+    {
+        EmitCommit(commit, sink);
+
+        if (options.IncludeFileChanges)
+            EmitFileChanges(commit, sink);
+
+        if (options.IncludeBranchEvents && branchTracker is not null)
+            EmitBranchEvents(commit, branchTracker, sink);
+
+        if (options.IncludeMergeDetection && commit.IsMerge)
+            EmitMergeEvent(commit, sink);
+    }
+
+    /// <summary>
+    /// Estimates the number of events that will be emitted for the supplied commits.
+    /// </summary>
+    internal static int EstimateCapacity(
+        IReadOnlyList<CommitData> commits,
+        TimelineBuilderOptions options)
+    {
+        long capacity = commits.Count;
+
+        if (options.IncludeFileChanges)
+        {
+            foreach (var t in commits)
+                capacity += t.FileChanges.Count;
+        }
+
+        if (options.IncludeBranchEvents)
+        {
+            foreach (var t in commits)
+                capacity += t.Branches.Count * 2L;
+        }
+
+        if (options.IncludeMergeDetection)
+        {
+            foreach (var t in commits)
+            {
+                if (t.IsMerge)
+                    capacity++;
+            }
+        }
+
+        return capacity >= int.MaxValue
+            ? int.MaxValue
+            : (int)capacity;
+    }
+
+    private static string BuildParentSummary(IReadOnlyList<CommitSha> parentShas)
+    {
+        if (parentShas.Count == 0)
+            return string.Empty;
+
+        if (parentShas.Count == 1)
+            return parentShas[0].Short;
+
+        var builder = new StringBuilder(parentShas.Count * 10);
+
+        for (var index = 0; index < parentShas.Count; index++)
+        {
+            if (index > 0)
+                builder.Append(", ");
+
+            builder.Append(parentShas[index].Short);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/GIt/Dto/TimelineDto.cs
+++ b/src/GIt/Dto/TimelineDto.cs
@@ -18,6 +18,12 @@ internal sealed record TimelineDto
 
     internal static TimelineDto FromDomain(Timeline timeline)
     {
+        var eventsSpan = timeline.EventsSpan;
+        var events = new List<TraceEventDto>(eventsSpan.Length);
+
+        for (var index = 0; index < eventsSpan.Length; index++)
+            events.Add(TraceEventDto.FromDomain(eventsSpan[index]));
+
         return new TimelineDto
         {
             RepositoryId = timeline.RepositoryId is not null
@@ -25,10 +31,7 @@ internal sealed record TimelineDto
                     timeline.RepositoryId.Owner,
                     timeline.RepositoryId.Name)
                 : null,
-
-            Events = timeline.Events
-                .Select(TraceEventDto.FromDomain)
-                .ToList(),
+            Events = events,
 
             IsNormalized = IsTimelineNormalized(timeline)
         };
@@ -42,11 +45,11 @@ internal sealed record TimelineDto
                 RepositoryId.Name).ValueOrNull
             : null;
 
-        var timeline = new Timeline(repositoryId);
+        var timeline = new Timeline(repositoryId, Events.Count);
 
-        foreach (var eventDto in Events)
+        for (var index = 0; index < Events.Count; index++)
         {
-            if (eventDto.ToDomain() is { } traceEvent)
+            if (Events[index].ToDomain() is { } traceEvent)
                 timeline.AddEvent(traceEvent);
         }
 

--- a/src/GIt/Dto/TraceEventDto.cs
+++ b/src/GIt/Dto/TraceEventDto.cs
@@ -1,7 +1,6 @@
 using ChangeTrace.Core.Enums;
 using ChangeTrace.Core.Events;
 using ChangeTrace.Core.Models;
-using ChangeTrace.Core.Results;
 using MessagePack;
 using Model = ChangeTrace.Core.Models;
 
@@ -59,17 +58,18 @@ internal sealed record TraceEventDto
     /// </summary>
     internal TraceEvent? ToDomain()
     {
-        var timestamp = TryCreate(() => Model.Timestamp.Create(Timestamp));
-        var actor = TryCreate(() => ActorName.Create(Actor));
-        if (actor == null) return null;
+        var timestamp = Model.Timestamp.Create(Timestamp).ValueOrNull;
+        var actor = ActorName.Create(Actor).ValueOrNull;
+        if (actor == null)
+            return null;
 
-        var sha = CommitSha != null ? TryCreate(() => Model.CommitSha.Create(CommitSha)) : null;
-        var branch = BranchName != null ? TryCreate(() => Model.BranchName.Create(BranchName)) : null;
+        var sha = CommitSha != null ? Model.CommitSha.Create(CommitSha).ValueOrNull : null;
+        var branch = BranchName != null ? Model.BranchName.Create(BranchName).ValueOrNull : null;
         var prNum = PullRequestNumber.HasValue
-            ? TryCreate(() => Model.PullRequestNumber.Create(PullRequestNumber.Value))
+            ? Model.PullRequestNumber.Create(PullRequestNumber.Value).ValueOrNull
             : (PullRequestNumber?)null;
-        
-        var evt = (sha, branch, FilePath, CommitType, BranchType) switch
+
+        TraceEvent? evt = (sha, branch, FilePath, CommitType, BranchType) switch
         {
             (not null, not null, _, _, "Merge")
                 => TraceEventFactory.Merge(timestamp, actor, sha, branch, Metadata),
@@ -80,12 +80,15 @@ internal sealed record TraceEventDto
             (not null, _, _, _, _) => TraceEventFactory.Commit(timestamp, actor, sha, Metadata),
             _ => null
         };
-        
-        if (evt != null && prNum != null && PrType != null && TryParseEnum<PullRequestEventType>(PrType) is var prType && prType != null)
+
+        if (evt is { } traceEvent &&
+            prNum != null &&
+            PrType != null &&
+            TryParseEnum<PullRequestEventType>(PrType) is { } prType)
         {
-            evt.Value.WithPullRequest(prNum.Value, prType.Value);
+            evt = traceEvent.WithPullRequest(prNum.Value, prType);
         }
-        
+
         return evt;
     }
 
@@ -94,7 +97,7 @@ internal sealed record TraceEventDto
         ActorName actor,
         CommitSha sha)
     {
-        var path = TryCreate(() => Model.FilePath.Create(FilePath));
+        var path = Model.FilePath.Create(FilePath).ValueOrNull;
         var changeType = TryParseEnum<FileChangeKind>(CommitType);
 
         return path != null && changeType != null
@@ -117,10 +120,4 @@ internal sealed record TraceEventDto
     
     private static TEnum? TryParseEnum<TEnum>(string? value) where TEnum : struct =>
         value != null && Enum.TryParse<TEnum>(value, out var r) ? r : null;
-    
-    private static T? TryCreate<T>(Func<Result<T>> factory)
-    {
-        var result = factory();
-        return result.IsSuccess ? result.Value : default;
-    }
 }

--- a/src/GIt/Interfaces/IStreamingTimelineRepository.cs
+++ b/src/GIt/Interfaces/IStreamingTimelineRepository.cs
@@ -1,0 +1,21 @@
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Options;
+using ChangeTrace.Core.Results;
+
+namespace ChangeTrace.GIt.Interfaces;
+
+/// <summary>
+/// Optional repository extension that can persist a timeline directly from a commit stream.
+/// </summary>
+internal interface IStreamingTimelineRepository
+{
+    /// <summary>
+    /// Persists timeline events directly from the source commit stream without
+    /// first materializing a full <see cref="ChangeTrace.Core.Timelines.Timeline"/>.
+    /// </summary>
+    Task<Result> SaveAsync(
+        IAsyncEnumerable<CommitData> commits,
+        string filePath,
+        TimelineBuilderOptions options,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GIt/Interfaces/ITimelineBuilder.cs
+++ b/src/GIt/Interfaces/ITimelineBuilder.cs
@@ -8,11 +8,7 @@ namespace ChangeTrace.GIt.Interfaces;
 
 internal interface ITimelineBuilder
 {
-    Result<Timeline> Build(
-        IReadOnlyList<CommitData> commits,
-        TimelineBuilderOptions options);
-
-    Task<Result<Timeline>> BuildAsync(
+    Task<Result<Timeline>> Build(
         IAsyncEnumerable<CommitData> commits,
         TimelineBuilderOptions options,
         CancellationToken cancellationToken = default);

--- a/src/GIt/Services/RepositoryExporter.cs
+++ b/src/GIt/Services/RepositoryExporter.cs
@@ -103,6 +103,66 @@ internal sealed class RepositoryExporter(
         ProgressCallback? progress = null,
         CancellationToken cancellationToken = default)
     {
+        if (repository is IStreamingTimelineRepository streamingRepository)
+        {
+            try
+            {
+                logger.LogInformation("Starting streaming export+save: {Path}", pathOrUrl);
+
+                progress?.Invoke("Prepare", 0, 4, "Preparing repository...");
+                var pathResult = await GetRepositoryPathStep(pathOrUrl, cancellationToken);
+                if (pathResult.IsFailure)
+                    return Result.Failure(pathResult.Error!);
+
+                var repoPath = pathResult.Value;
+                progress?.Invoke("Prepare", 1, 4, "Repository ready");
+
+                var repositoryId = ExtractRepositoryId(pathOrUrl);
+                progress?.Invoke("Read", 1, 4, "Reading commits...");
+
+                var backend = SelectHistoryBackend(repoPath, options);
+                var commitsResult = await gitReader.ReadCommitsStreamAsync(
+                    repoPath,
+                    new GitReaderOptions(
+                        IncludeFileChanges: options.IncludeFileChanges,
+                        MaxCommits: options.MaxCommits,
+                        StartDate: options.StartDate,
+                        EndDate: options.EndDate,
+                        Backend: backend,
+                        DetectRenames: options.DetectRenames,
+                        IncludeBranches: options.IncludeBranchEvents || options.IncludeMergeDetection
+                    ),
+                    cancellationToken);
+
+                if (commitsResult.IsFailure)
+                    return Result.Failure(commitsResult.Error!);
+
+                progress?.Invoke("Build", 2, 4, "Streaming timeline to repository...");
+
+                var streamSaveResult = await streamingRepository.SaveAsync(
+                    commitsResult.Value,
+                    outputPath,
+                    new TimelineBuilderOptions(
+                        IncludeFileChanges: options.IncludeFileChanges,
+                        IncludeBranchEvents: options.IncludeBranchEvents,
+                        IncludeMergeDetection: options.IncludeMergeDetection,
+                        RepositoryId: repositoryId),
+                    cancellationToken);
+
+                if (streamSaveResult.IsFailure)
+                    return Result.Failure(streamSaveResult.Error!);
+
+                progress?.Invoke("Complete", 4, 4, "Export complete");
+                logger.LogInformation("Timeline saved to: {Path}", outputPath);
+                return Result.Success();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Streaming export+save failed");
+                return Result.Failure("Export failed", ex);
+            }
+        }
+
         var exportResult = await ExportAsync(pathOrUrl, options, progress, cancellationToken);
 
         if (exportResult.IsFailure)
@@ -189,7 +249,7 @@ internal sealed class RepositoryExporter(
             RepositoryId: repositoryId
         );
 
-        return await timelineBuilder.BuildAsync(commitsResult.Value, builderOptions, ct);
+        return await timelineBuilder.Build(commitsResult.Value, builderOptions, ct);
     }
 
     private GitHistoryReaderBackend SelectHistoryBackend(
@@ -299,16 +359,14 @@ internal sealed class RepositoryExporter(
     {
         try
         {
-            using var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo
             {
-                StartInfo = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "git",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = "git",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
             process.StartInfo.ArgumentList.Add("--version");
             process.Start();
@@ -325,16 +383,14 @@ internal sealed class RepositoryExporter(
     {
         try
         {
-            using var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo
             {
-                StartInfo = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "git",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = "git",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
 
             process.StartInfo.ArgumentList.Add("-C");

--- a/src/GIt/Services/TimelineMessagePackFormatter.cs
+++ b/src/GIt/Services/TimelineMessagePackFormatter.cs
@@ -1,6 +1,8 @@
 using ChangeTrace.Configuration.Discovery;
+using ChangeTrace.Core.Enums;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
 using ChangeTrace.Core.Timelines;
-using ChangeTrace.GIt.Dto;
 using MessagePack;
 using MessagePack.Formatters;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,22 +10,493 @@ using Microsoft.Extensions.DependencyInjection;
 namespace ChangeTrace.GIt.Services;
 
 /// <summary>
-/// MessagePack formatter that maps <see cref="Timeline"/> through its persistence DTO.
+/// MessagePack formatter for timelines.
 /// </summary>
 [AutoRegister(ServiceLifetime.Singleton, typeof(IMessagePackFormatter<Timeline>))]
 internal sealed class TimelineMessagePackFormatter : IMessagePackFormatter<Timeline>
 {
+    /// <summary>
+    /// Serializes a timeline to MessagePack.
+    /// </summary>
     public void Serialize(ref MessagePackWriter writer, Timeline value, MessagePackSerializerOptions options)
     {
-        var dto = TimelineDto.FromDomain(value);
-        MessagePackSerializer.Serialize(ref writer, dto, options);
+        writer.WriteArrayHeader(4);
+        writer.WriteNil();
+
+        WriteRepositoryId(ref writer, value);
+        WriteEvents(ref writer, value);
+        writer.Write(IsTimelineNormalized(value));
     }
 
+    /// <summary>
+    /// Deserializes a timeline from MessagePack.
+    /// </summary>
     public Timeline Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
-        var dto = MessagePackSerializer.Deserialize<TimelineDto>(ref reader, options);
+        if (reader.TryReadNil())
+            throw new InvalidOperationException("Deserialized timeline payload is null.");
 
-        return dto?.ToDomain()
-            ?? throw new InvalidOperationException("Deserialized timeline DTO is null.");
+        var count = reader.ReadArrayHeader();
+        RepositoryId? repositoryId = null;
+        Timeline? timeline = null;
+
+        for (var index = 0; index < count; index++)
+        {
+            switch (index)
+            {
+                case 0:
+                    reader.Skip();
+                    break;
+                case 1:
+                    repositoryId = ReadRepositoryId(ref reader);
+                    break;
+                case 2:
+                    timeline = ReadTimelineEvents(ref reader, repositoryId);
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        return timeline ?? new Timeline(repositoryId);
+    }
+
+    /// <summary>
+    /// Writes the repository identifier payload.
+    /// </summary>
+    internal static void WriteRepositoryId(ref MessagePackWriter writer, RepositoryId? repositoryId)
+    {
+        if (repositoryId is not { } value)
+        {
+            writer.WriteNil();
+            return;
+        }
+
+        writer.WriteArrayHeader(2);
+        writer.Write(value.Owner);
+        writer.Write(value.Name);
+    }
+
+    private static void WriteRepositoryId(ref MessagePackWriter writer, Timeline timeline)
+    {
+        WriteRepositoryId(ref writer, timeline.RepositoryId);
+    }
+
+    /// <summary>
+    /// Writes timeline events.
+    /// </summary>
+    private static void WriteEvents(ref MessagePackWriter writer, Timeline timeline)
+    {
+        var events = timeline.EventsSpan;
+        writer.WriteArrayHeader(events.Length);
+
+        for (var index = 0; index < events.Length; index++)
+            WriteEvent(ref writer, events[index]);
+    }
+
+    /// <summary>
+    /// Writes a single timeline event.
+    /// </summary>
+    internal static void WriteEvent(ref MessagePackWriter writer, TraceEvent traceEvent)
+    {
+        writer.WriteArrayHeader(11);
+        writer.Write(traceEvent.Core.Timestamp.UnixSeconds);
+        writer.Write(traceEvent.Core.Actor.Value);
+        writer.Write(traceEvent.Target);
+        WriteNullableString(ref writer, traceEvent.Metadata?.Metadata);
+        WriteNullableString(ref writer, traceEvent.Commit?.Sha.Value);
+        WriteNullableString(ref writer, traceEvent.Branch?.Name.Value);
+        WriteNullableInt32(ref writer, traceEvent.PullRequest?.Number.Value);
+        WriteNullableString(ref writer, traceEvent.Metadata?.FilePath?.Value);
+        WriteNullableByte(ref writer, EncodeCommitType(traceEvent.Commit?.Type));
+        WriteNullableByte(ref writer, EncodeBranchType(traceEvent.Branch?.Type));
+        WriteNullableByte(ref writer, EncodePullRequestType(traceEvent.PullRequest?.Type));
+    }
+
+    /// <summary>
+    /// Reads the repository identifier payload.
+    /// </summary>
+    private static RepositoryId? ReadRepositoryId(ref MessagePackReader reader)
+    {
+        if (reader.TryReadNil())
+            return null;
+
+        var length = reader.ReadArrayHeader();
+        string? owner = null;
+        string? name = null;
+
+        if (length > 0)
+            owner = reader.ReadString();
+        if (length > 1)
+            name = reader.ReadString();
+        for (var index = 2; index < length; index++)
+            reader.Skip();
+
+        return owner != null && name != null
+            ? RepositoryId.FromTrustedSerialized(owner, name)
+            : null;
+    }
+
+    /// <summary>
+    /// Reads timeline events.
+    /// </summary>
+    private static Timeline ReadTimelineEvents(
+        ref MessagePackReader reader,
+        RepositoryId? repositoryId)
+    {
+        var eventCount = reader.ReadArrayHeader();
+        var timeline = new Timeline(repositoryId, eventCount);
+
+        for (var index = 0; index < eventCount; index++)
+        {
+            if (ReadEvent(ref reader) is { } traceEvent)
+                timeline.AddEvent(traceEvent);
+        }
+
+        return timeline;
+    }
+
+    /// <summary>
+    /// Reads a single timeline event.
+    /// </summary>
+    private static TraceEvent? ReadEvent(ref MessagePackReader reader)
+    {
+        if (reader.TryReadNil())
+            return null;
+
+        var length = reader.ReadArrayHeader();
+        long timestampValue = default;
+        string? actorValue = null;
+        string? metadata = null;
+        string? commitSha = null;
+        string? branchName = null;
+        int? pullRequestNumber = null;
+        string? filePath = null;
+        byte? commitType = null;
+        byte? branchType = null;
+        byte? pullRequestType = null;
+
+        for (var index = 0; index < length; index++)
+        {
+            switch (index)
+            {
+                case 0:
+                    timestampValue = reader.ReadInt64();
+                    break;
+                case 1:
+                    actorValue = reader.ReadString();
+                    break;
+                case 2:
+                    reader.Skip();
+                    break;
+                case 3:
+                    metadata = reader.TryReadNil() ? null : reader.ReadString();
+                    break;
+                case 4:
+                    commitSha = reader.TryReadNil() ? null : reader.ReadString();
+                    break;
+                case 5:
+                    branchName = reader.TryReadNil() ? null : reader.ReadString();
+                    break;
+                case 6:
+                    pullRequestNumber = reader.TryReadNil() ? null : reader.ReadInt32();
+                    break;
+                case 7:
+                    filePath = reader.TryReadNil() ? null : reader.ReadString();
+                    break;
+                case 8:
+                    commitType = ReadNullableByte(ref reader, TryDecodeCommitTypeFromString);
+                    break;
+                case 9:
+                    branchType = ReadNullableByte(ref reader, TryDecodeBranchTypeFromString);
+                    break;
+                case 10:
+                    pullRequestType = ReadNullableByte(ref reader, TryDecodePullRequestTypeFromString);
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        var timestamp = Timestamp.FromTrustedUnixSeconds(timestampValue);
+        var actor = actorValue != null ? ActorName.FromTrustedSerialized(actorValue) : null;
+        if (actor == null)
+            return null;
+
+        var sha = commitSha != null ? CommitSha.FromTrustedSerialized(commitSha) : null;
+        var branch = branchName != null ? BranchName.FromTrustedSerialized(branchName) : null;
+        var prNumber = pullRequestNumber.HasValue
+            ? PullRequestNumber.Create(pullRequestNumber.Value).ValueOrNull
+            : (PullRequestNumber?)null;
+
+        TraceEvent? traceEvent;
+
+        if (sha != null && branch != null && DecodeBranchType(branchType) == BranchEventType.Merge)
+        {
+            traceEvent = TraceEventFactory.Merge(timestamp, actor, sha, branch, metadata);
+        }
+        else if (sha != null && filePath != null && commitType.HasValue)
+        {
+            traceEvent = CreateFileChangeEvent(timestamp, actor, sha, filePath, commitType.Value, metadata);
+        }
+        else if (branch != null && branchType.HasValue)
+        {
+            traceEvent = CreateBranchEvent(timestamp, actor, branch, sha, branchType.Value, metadata);
+        }
+        else if (sha != null)
+        {
+            traceEvent = TraceEventFactory.Commit(timestamp, actor, sha, metadata);
+        }
+        else
+        {
+            traceEvent = null;
+        }
+
+        if (traceEvent is { } eventValue &&
+            prNumber != null &&
+            DecodePullRequestType(pullRequestType) is { } prType)
+        {
+            traceEvent = eventValue.WithPullRequest(prNumber.Value, prType);
+        }
+
+        return traceEvent;
+    }
+
+    /// <summary>
+    /// Creates a file change event.
+    /// </summary>
+    private static TraceEvent? CreateFileChangeEvent(
+        Timestamp timestamp,
+        ActorName actor,
+        CommitSha sha,
+        string filePath,
+        byte commitType,
+        string? metadata)
+    {
+        var path = FilePath.FromTrustedSerialized(filePath);
+        var type = DecodeCommitType(commitType);
+
+        return path != null && type != null
+            ? TraceEventFactory.FileChange(timestamp, actor, path, type.Value, sha, metadata)
+            : null;
+    }
+
+    /// <summary>
+    /// Creates a branch event.
+    /// </summary>
+    private static TraceEvent? CreateBranchEvent(
+        Timestamp timestamp,
+        ActorName actor,
+        BranchName branch,
+        CommitSha? sha,
+        byte branchType,
+        string? metadata)
+    {
+        var type = DecodeBranchType(branchType);
+
+        return type != null
+            ? TraceEventFactory.Branch(timestamp, actor, branch, type.Value, sha, metadata)
+            : null;
+    }
+
+    /// <summary>
+    /// Encodes a file change type.
+    /// </summary>
+    private static byte? EncodeCommitType(FileChangeKind? type) => type switch
+    {
+        FileChangeKind.Commit => 0,
+        FileChangeKind.Added => 1,
+        FileChangeKind.Modified => 2,
+        FileChangeKind.Deleted => 3,
+        FileChangeKind.Renamed => 4,
+        _ => null
+    };
+
+    /// <summary>
+    /// Encodes a branch event type.
+    /// </summary>
+    private static byte? EncodeBranchType(BranchEventType? type) => type switch
+    {
+        BranchEventType.BranchCreated => 0,
+        BranchEventType.BranchDeleted => 1,
+        BranchEventType.Merge => 2,
+        _ => null
+    };
+
+    /// <summary>
+    /// Encodes a pull request event type.
+    /// </summary>
+    private static byte? EncodePullRequestType(PullRequestEventType? type) => type switch
+    {
+        PullRequestEventType.PullRequestCreated => 0,
+        PullRequestEventType.PullRequestMerged => 1,
+        PullRequestEventType.PullRequestClosed => 2,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a file change type.
+    /// </summary>
+    private static FileChangeKind? DecodeCommitType(byte? value) => value switch
+    {
+        0 => FileChangeKind.Commit,
+        1 => FileChangeKind.Added,
+        2 => FileChangeKind.Modified,
+        3 => FileChangeKind.Deleted,
+        4 => FileChangeKind.Renamed,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a branch event type.
+    /// </summary>
+    private static BranchEventType? DecodeBranchType(byte? value) => value switch
+    {
+        0 => BranchEventType.BranchCreated,
+        1 => BranchEventType.BranchDeleted,
+        2 => BranchEventType.Merge,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a pull request event type.
+    /// </summary>
+    private static PullRequestEventType? DecodePullRequestType(byte? value) => value switch
+    {
+        0 => PullRequestEventType.PullRequestCreated,
+        1 => PullRequestEventType.PullRequestMerged,
+        2 => PullRequestEventType.PullRequestClosed,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a legacy file change type string.
+    /// </summary>
+    private static byte? TryDecodeCommitTypeFromString(string? value) => value switch
+    {
+        nameof(FileChangeKind.Commit) => 0,
+        nameof(FileChangeKind.Added) => 1,
+        nameof(FileChangeKind.Modified) => 2,
+        nameof(FileChangeKind.Deleted) => 3,
+        nameof(FileChangeKind.Renamed) => 4,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a legacy branch event type string.
+    /// </summary>
+    private static byte? TryDecodeBranchTypeFromString(string? value) => value switch
+    {
+        nameof(BranchEventType.BranchCreated) => 0,
+        nameof(BranchEventType.BranchDeleted) => 1,
+        nameof(BranchEventType.Merge) => 2,
+        _ => null
+    };
+
+    /// <summary>
+    /// Decodes a legacy pull request event type string.
+    /// </summary>
+    private static byte? TryDecodePullRequestTypeFromString(string? value) => value switch
+    {
+        nameof(PullRequestEventType.PullRequestCreated) => 0,
+        nameof(PullRequestEventType.PullRequestMerged) => 1,
+        nameof(PullRequestEventType.PullRequestClosed) => 2,
+        _ => null
+    };
+
+    /// <summary>
+    /// Writes an optional string value.
+    /// </summary>
+    private static void WriteNullableString(ref MessagePackWriter writer, string? value)
+    {
+        if (value == null)
+        {
+            writer.WriteNil();
+            return;
+        }
+
+        writer.Write(value);
+    }
+
+    /// <summary>
+    /// Writes an optional 32-bit integer value.
+    /// </summary>
+    private static void WriteNullableInt32(ref MessagePackWriter writer, int? value)
+    {
+        if (!value.HasValue)
+        {
+            writer.WriteNil();
+            return;
+        }
+
+        writer.Write(value.Value);
+    }
+
+    /// <summary>
+    /// Writes an optional byte value.
+    /// </summary>
+    private static void WriteNullableByte(ref MessagePackWriter writer, byte? value)
+    {
+        if (!value.HasValue)
+        {
+            writer.WriteNil();
+            return;
+        }
+
+        writer.Write(value.Value);
+    }
+
+    /// <summary>
+    /// Reads an optional byte value.
+    /// </summary>
+    private static byte? ReadNullableByte(
+        ref MessagePackReader reader,
+        Func<string?, byte?> legacyStringDecoder)
+    {
+        if (reader.TryReadNil())
+            return null;
+
+        return reader.NextMessagePackType switch
+        {
+            MessagePackType.Integer => reader.ReadByte(),
+            MessagePackType.String => legacyStringDecoder(reader.ReadString()),
+            _ => SkipUnsupportedByteLike(ref reader)
+        };
+    }
+
+    /// <summary>
+    /// Skips an unsupported byte-like value.
+    /// </summary>
+    private static byte? SkipUnsupportedByteLike(ref MessagePackReader reader)
+    {
+        reader.Skip();
+        return null;
+    }
+
+    /// <summary>
+    /// Checks whether the timeline is ordered by timestamp.
+    /// </summary>
+    private static bool IsTimelineNormalized(Timeline timeline)
+    {
+        var events = timeline.EventsSpan;
+
+        if (events.Length <= 1)
+            return true;
+
+        var previousTimestamp = events[0].Core.Timestamp;
+
+        for (var index = 1; index < events.Length; index++)
+        {
+            var currentTimestamp = events[index].Core.Timestamp;
+
+            if (currentTimestamp < previousTimestamp)
+                return false;
+
+            previousTimestamp = currentTimestamp;
+        }
+
+        return true;
     }
 }

--- a/src/GIt/Services/TimelineRepositoryMsgPack.Debug.cs
+++ b/src/GIt/Services/TimelineRepositoryMsgPack.Debug.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Timelines;
+using Microsoft.Extensions.Logging;
+
+namespace ChangeTrace.GIt.Services;
+
+/// <summary>
+/// Debug snapshot output for timeline saves.
+/// </summary>
+internal sealed partial class TimelineRepositoryMsgPack
+{
+    /// <summary>
+    /// Enables debug snapshot writes for small timelines.
+    /// </summary>
+    private bool ShouldWriteDebugSnapshot(Timeline timeline)
+        => (logger.IsEnabled(LogLevel.Debug) || logger.GetType().Name.StartsWith("NullLogger"))
+           && timeline.Events.Count <= 50000;
+
+    /// <summary>
+    /// Writes a JSON debug snapshot alongside the saved timeline.
+    /// </summary>
+    private static async Task WriteDebugSnapshotAsync(
+        Timeline timeline,
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = CreateDebugSnapshot(timeline);
+        var json = JsonSerializer.Serialize(
+            snapshot,
+            new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+        await File.WriteAllTextAsync(filePath + ".debug.json", json, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates the debug snapshot payload.
+    /// </summary>
+    private static DebugTimelineSnapshot CreateDebugSnapshot(Timeline timeline)
+    {
+        var repository = timeline.RepositoryId is { } repositoryId
+            ? new DebugRepositorySnapshot(repositoryId.Owner, repositoryId.Name)
+            : null;
+
+        return new DebugTimelineSnapshot(
+            repository,
+            timeline.Events.Count,
+            timeline.Events.Select(DebugTimelineEventSnapshot.From).ToList());
+    }
+
+    /// <summary>
+    /// Timeline debug snapshot root.
+    /// </summary>
+    private sealed class DebugTimelineSnapshot(
+        DebugRepositorySnapshot? repository,
+        int eventCount,
+        IReadOnlyList<DebugTimelineEventSnapshot> events)
+    {
+        public DebugRepositorySnapshot? Repository { get; } = repository;
+        public int EventCount { get; } = eventCount;
+        public IReadOnlyList<DebugTimelineEventSnapshot> Events { get; } = events;
+    }
+
+    /// <summary>
+    /// Repository debug snapshot.
+    /// </summary>
+    private sealed class DebugRepositorySnapshot(string owner, string name)
+    {
+        public string Owner { get; } = owner;
+        public string Name { get; } = name;
+    }
+
+    /// <summary>
+    /// Timeline event debug snapshot.
+    /// </summary>
+    private sealed class DebugTimelineEventSnapshot(
+        long timestamp,
+        string? actor,
+        string? branch,
+        object? branchType,
+        string? commitSha,
+        object? commitType,
+        string? filePath,
+        string? metadataMessage,
+        string target)
+    {
+        public long Timestamp { get; } = timestamp;
+        public string? Actor { get; } = actor;
+        public string? Branch { get; } = branch;
+        public object? BranchType { get; } = branchType;
+        public string? CommitSha { get; } = commitSha;
+        public object? CommitType { get; } = commitType;
+        public string? FilePath { get; } = filePath;
+        public string? MetadataMessage { get; } = metadataMessage;
+        public string Target { get; } = target;
+
+        /// <summary>
+        /// Creates a snapshot from a timeline event.
+        /// </summary>
+        public static DebugTimelineEventSnapshot From(TraceEvent evt)
+        {
+            var branch = evt.Branch;
+            var commit = evt.Commit;
+            var metadata = evt.Metadata;
+
+            return new DebugTimelineEventSnapshot(
+                evt.Core.Timestamp.UnixSeconds,
+                evt.Core.Actor.Value,
+                branch?.Name.Value,
+                branch?.Type,
+                commit?.Sha.Value,
+                commit?.Type,
+                metadata?.FilePath?.Value,
+                metadata?.Metadata,
+                evt.Target);
+        }
+    }
+}

--- a/src/GIt/Services/TimelineRepositoryMsgPack.cs
+++ b/src/GIt/Services/TimelineRepositoryMsgPack.cs
@@ -1,96 +1,48 @@
+using System.Buffers;
 using ChangeTrace.Configuration.Discovery;
-using ChangeTrace.Core;
+using ChangeTrace.Core.Events;
 using ChangeTrace.Core.Interfaces;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Options;
 using ChangeTrace.Core.Results;
+using ChangeTrace.Core.Services;
 using ChangeTrace.Core.Timelines;
 using ChangeTrace.GIt.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MessagePack;
 
 namespace ChangeTrace.GIt.Services;
 
 /// <summary>
-/// Repository implementation for persisting and loading <see cref="Timeline"/> objects
-/// using MsgPack serialization.
+/// Saves and loads timelines using MsgPack.
+/// Handles .gittrace persistence and streaming export writes.
 /// </summary>
-/// <remarks>
-/// This class handles the full lifecycle of timeline storage:
-/// <list type="bullet">
-/// <item>Automatically appends the <c>.gittrace</c> extension when saving or loading files.</item>
-/// <item>Delegates serialization to <see cref="ISerializer{T}"/> for <see cref="Timeline"/>.</item>
-/// <item>Delegates file I/O to <see cref="IFileManager"/>.</item>
-/// <item>Returns <see cref="Result"/> or <see cref="Result{T}"/> objects to encapsulate success or failure without throwing exceptions.</item>
-/// <item>Designed as a singleton service for dependency injection with <see cref="ServiceLifetime.Singleton"/>.</item>
-/// </list>
-/// </remarks>
 [AutoRegister(ServiceLifetime.Singleton)]
-internal sealed class TimelineRepositoryMsgPack(
+internal sealed partial class TimelineRepositoryMsgPack(
     ILogger<TimelineRepositoryMsgPack> logger,
     ISerializer<Timeline> serializer,
     IFileManager fileManager)
-    : ITimelineRepository
+    : ITimelineRepository, IStreamingTimelineRepository
 {
     private const string FileExtension = ".gittrace";
 
     /// <summary>
-    /// Saves the given <paramref name="timeline"/> to the specified <paramref name="filePath"/>.
-    /// Automatically creates the directory if it does not exist.
+    /// Saves a timeline to disk.
     /// </summary>
-    /// <param name="timeline">The timeline to persist.</param>
-    /// <param name="filePath">The file path where the timeline should be saved.</param>
-    /// <param name="cancellationToken">Token to cancel the operation.</param>
-    /// <returns>
-    /// A <see cref="Result"/> indicating success or failure. 
-    /// On failure, contains the error message and exception.
-    /// </returns>
     public async Task<Result> SaveAsync(Timeline timeline, string filePath, CancellationToken cancellationToken = default)
     {
         try
         {
             filePath = fileManager.EnsureExtension(filePath, FileExtension);
             logger.LogInformation("Saving timeline to {Path}", filePath);
-            var bytes = await serializer.SerializeAsync(timeline, cancellationToken);
-            await fileManager.SaveAsync(filePath, bytes, cancellationToken);
+            var byteLength = await WriteTimelineAsync(filePath, timeline, cancellationToken);
 
-        logger.LogInformation("Timeline saved successfully ({Length} bytes)", bytes.Length);
-            
-            
-            if ((logger.IsEnabled(LogLevel.Debug) || logger.GetType().Name.StartsWith("NullLogger")) && timeline.Events.Count <= 50000)
-            {
-                var debugObject = new
-                {
-                    Repository = timeline.RepositoryId != null
-                        ? new
-                        {
-                            timeline.RepositoryId.Owner,
-                            timeline.RepositoryId.Name
-                        }
-                        : null,
-                    EventCount = timeline.Events.Count,
-                    Events = timeline.Events.Select(evt => new
-                    {
-                        Timestamp = evt.Core.Timestamp.UnixSeconds,
-                        Actor = evt.Core.Actor?.Value,
-                        Branch = evt.Branch?.Name?.Value,
-                        BranchType = evt.Branch?.Type,
-                        CommitSha = evt.Commit?.Sha?.Value,
-                        CommitType = evt.Commit?.Type,
-                        FilePath = evt.Metadata?.FilePath?.Value,
-                        MetadataMessage = evt.Metadata?.Metadata,
-                        Target = evt.Target
-                    }).ToList()
-                };
-                var json = System.Text.Json.JsonSerializer.Serialize(
-                    debugObject,
-                    new System.Text.Json.JsonSerializerOptions
-                    {
-                        WriteIndented = true
-                    });
+            logger.LogInformation("Timeline saved successfully ({Length} bytes)", byteLength);
 
-                var debugPath = filePath + ".debug.json";
-                await File.WriteAllTextAsync(debugPath, json, cancellationToken);
-            }
-            
+            if (ShouldWriteDebugSnapshot(timeline))
+                await WriteDebugSnapshotAsync(timeline, filePath, cancellationToken);
+
             return Result.Success();
         }
         catch (Exception ex)
@@ -101,22 +53,77 @@ internal sealed class TimelineRepositoryMsgPack(
     }
 
     /// <summary>
-    /// Loads a <see cref="Timeline"/> from the specified <paramref name="filePath"/>.
+    /// Streams commits into a timeline file.
     /// </summary>
-    /// <param name="filePath">The file path to load the timeline from.</param>
-    /// <param name="cancellationToken">Token to cancel the operation.</param>
-    /// <returns>
-    /// A <see cref="Result{Timeline}"/> containing the loaded timeline on success,
-    /// or failure information if loading or deserialization fails.
-    /// </returns>
+    public async Task<Result> SaveAsync(
+        IAsyncEnumerable<CommitData> commits,
+        string filePath,
+        TimelineBuilderOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        string? tempEventsPath = null;
+
+        try
+        {
+            filePath = fileManager.EnsureExtension(filePath, FileExtension);
+            logger.LogInformation("Streaming timeline save to {Path}", filePath);
+
+            tempEventsPath = Path.Combine(
+                Path.GetTempPath(),
+                "ChangeTrace",
+                "timeline-events",
+                $"{Guid.NewGuid():N}.bin");
+
+            var eventCount = await WriteEventPayloadAsync(
+                commits,
+                tempEventsPath,
+                options,
+                cancellationToken);
+
+            await using var outputStream = await fileManager.OpenWriteAsync(filePath, cancellationToken);
+            await WriteTimelinePayloadAsync(
+                outputStream,
+                tempEventsPath,
+                eventCount,
+                options.RepositoryId,
+                cancellationToken);
+
+            logger.LogInformation("Timeline streamed successfully ({Count} events)", eventCount);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to stream save timeline");
+            return Result.Failure("Failed to save timeline", ex);
+        }
+        finally
+        {
+            if (tempEventsPath is not null && File.Exists(tempEventsPath))
+                File.Delete(tempEventsPath);
+        }
+    }
+
+    /// <summary>
+    /// Loads a timeline from disk.
+    /// </summary>
     public async Task<Result<Timeline>> LoadAsync(string filePath, CancellationToken cancellationToken = default)
     {
         try
         {
             logger.LogInformation("Loading timeline from {Path}", filePath);
 
-            var bytes = await fileManager.LoadAsync(filePath, cancellationToken);
-            var timeline = await serializer.DeserializeAsync(bytes, cancellationToken);
+            Timeline timeline;
+
+            if (serializer is IStreamingSerializer<Timeline> streamingSerializer)
+            {
+                await using var stream = await fileManager.OpenReadAsync(filePath, cancellationToken);
+                timeline = await streamingSerializer.DeserializeAsync(stream, cancellationToken);
+            }
+            else
+            {
+                var bytes = await fileManager.LoadAsync(filePath, cancellationToken);
+                timeline = await serializer.DeserializeAsync(bytes, cancellationToken);
+            }
 
             logger.LogInformation("Timeline loaded: {Count} events", timeline.Count);
             return Result<Timeline>.Success(timeline);
@@ -125,6 +132,123 @@ internal sealed class TimelineRepositoryMsgPack(
         {
             logger.LogError(ex, "Failed to load timeline");
             return Result<Timeline>.Failure("Failed to load timeline", ex);
+        }
+    }
+
+    private async Task<long> WriteTimelineAsync(
+        string filePath,
+        Timeline timeline,
+        CancellationToken cancellationToken)
+    {
+        if (serializer is IStreamingSerializer<Timeline> streamingSerializer)
+            return await WriteTimelineStreamAsync(filePath, timeline, streamingSerializer, cancellationToken);
+
+        return await WriteTimelineBufferAsync(filePath, timeline, cancellationToken);
+    }
+
+    private async Task<long> WriteTimelineStreamAsync(
+        string filePath,
+        Timeline timeline,
+        IStreamingSerializer<Timeline> streamingSerializer,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = await fileManager.OpenWriteAsync(filePath, cancellationToken);
+        await streamingSerializer.SerializeAsync(stream, timeline, cancellationToken);
+        await stream.FlushAsync(cancellationToken);
+
+        return stream.CanSeek ? stream.Length : -1;
+    }
+
+    private async Task<long> WriteTimelineBufferAsync(
+        string filePath,
+        Timeline timeline,
+        CancellationToken cancellationToken)
+    {
+        var bytes = await serializer.SerializeAsync(timeline, cancellationToken);
+        await fileManager.SaveAsync(filePath, bytes, cancellationToken);
+        return bytes.Length;
+    }
+
+    private async Task<int> WriteEventPayloadAsync(
+        IAsyncEnumerable<CommitData> commits,
+        string tempEventsPath,
+        TimelineBuilderOptions options,
+        CancellationToken cancellationToken)
+    {
+        await using var tempStream = await fileManager.OpenWriteAsync(tempEventsPath, cancellationToken);
+        var writer = new EventPayloadWriter(tempStream);
+        var branchTracker = options.IncludeBranchEvents
+            ? new BranchTracker()
+            : null;
+        var commitCount = 0;
+
+        await foreach (var commit in commits.WithCancellation(cancellationToken))
+        {
+            TimelineEventEmitter.EmitCommitEvents(
+                commit,
+                options,
+                branchTracker,
+                writer.Write);
+
+            commitCount++;
+            if (commitCount % 50000 == 0)
+                logger.LogInformation("Stream-saved {Count} commits...", commitCount);
+        }
+
+        await tempStream.FlushAsync(cancellationToken);
+        return writer.EventCount;
+    }
+
+    private static async Task WriteTimelinePayloadAsync(
+        Stream outputStream,
+        string tempEventsPath,
+        int eventCount,
+        RepositoryId? repositoryId,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new ArrayBufferWriter<byte>(256);
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteArrayHeader(4);
+        writer.WriteNil();
+        TimelineMessagePackFormatter.WriteRepositoryId(ref writer, repositoryId);
+        writer.WriteArrayHeader(eventCount);
+        writer.Flush();
+
+        await outputStream.WriteAsync(buffer.WrittenMemory, cancellationToken);
+
+        await using (var tempReadStream = new FileStream(
+                         tempEventsPath,
+                         FileMode.Open,
+                         FileAccess.Read,
+                         FileShare.Read,
+                         131072,
+                         FileOptions.Asynchronous | FileOptions.SequentialScan))
+        {
+            await tempReadStream.CopyToAsync(outputStream, 131072, cancellationToken);
+        }
+
+        buffer.Clear();
+        writer = new MessagePackWriter(buffer);
+        writer.Write(false);
+        writer.Flush();
+        await outputStream.WriteAsync(buffer.WrittenMemory, cancellationToken);
+        await outputStream.FlushAsync(cancellationToken);
+    }
+
+    private sealed class EventPayloadWriter(Stream stream)
+    {
+        private readonly ArrayBufferWriter<byte> _buffer = new(1024);
+
+        public int EventCount { get; private set; }
+
+        public void Write(TraceEvent traceEvent)
+        {
+            _buffer.Clear();
+            var writer = new MessagePackWriter(_buffer);
+            TimelineMessagePackFormatter.WriteEvent(ref writer, traceEvent);
+            writer.Flush();
+            stream.Write(_buffer.WrittenSpan);
+            EventCount++;
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR does two concrete things in the codebase:

- streams timeline exports directly to \.gittrace without materializing the full timeline for the common repository persistence flow
- optimizes the \.gittrace serialization pipeline with trusted deserialization helpers, direct formatter writes, and repository benchmark coverage

Closes #37
Closes #27

## Streaming Export

- adds a streaming serializer contract for timeline persistence
- adds a stream-aware file loader used by the CLI timeline viewers and debug entrypoints
- adds a persist-only repository path that writes commit stream events directly into \.gittrace
- keeps the existing timeline model intact for in-memory builds and regular serialization flows
- isolates debug JSON snapshot output from the main repository implementation via a partial class
- adds an end-to-end export benchmark that exercises the streaming repository path

## Serialization Pipeline

- removes the intermediate DTO hop from the timeline MessagePack formatter
- adds trusted deserialization helpers for timeline persistence value objects
- preallocates DTO collections and timeline storage during roundtrip conversion
- preserves the existing payload shape and roundtrip behavior while reducing allocation pressure
- adds repository MsgPack benchmark coverage for save and load paths
- keeps pull request metadata roundtrip coverage in serializer tests

## Coverage in This PR

- validates the streaming repository flow with repository and file manager tests
- validates the optimized timeline MessagePack roundtrip path with serializer tests
- keeps benchmark baselines for both repository export and repository serialization paths in the new suite layout

## Result

- large repository exports no longer require the common full-byte-array persistence path when stream support is available
- \.gittrace serialization now runs with lower managed memory pressure and less conversion overhead
- the repository keeps the same timeline payload model and remains compatible with existing roundtrip tests
- the export and serialization benchmarks provide dedicated regression coverage for the two optimized flows