### PR TITLE
Fix: Skip unavailable GitHub PR enrichment

### DIFF
--- a/Tests/Unit/GIt/Enrichers/GitHubEnricherTests.cs
+++ b/Tests/Unit/GIt/Enrichers/GitHubEnricherTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using ChangeTrace.Core.Events;
+using ChangeTrace.Core.Models;
+using ChangeTrace.Core.Timelines;
+using ChangeTrace.GIt.Enrichers;
+using ChangeTrace.GIt.Interfaces;
+using ChangeTrace.GIt.Options;
+using ChangeTrace.GIt.Services.Checkpoints.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Octokit;
+using Xunit;
+
+namespace ChangeTrace.Tests.GIt.Enrichers;
+
+public sealed class GitHubEnricherTests
+{
+    [Fact]
+    public async Task EnrichAsync_SkipsPullRequestEnrichmentWhenGitHubReturnsNotFound()
+    {
+        var checkpointStore = new TestExportCheckpointStore();
+        var enricher = new NotFoundGitHubEnricher(checkpointStore);
+        var repositoryId = RepositoryId.Create("torvalds", "linux").Value;
+        var timeline = new Timeline(repositoryId);
+        timeline.AddEvent(TraceEventFactory.Commit(
+            Timestamp.Create(1_735_689_600).Value,
+            ActorName.Create("linus").Value,
+            CommitSha.Create("0123456789abcdef0123456789abcdef01234567").Value,
+            "metadata"));
+
+        var result = await enricher.Enrich(timeline, repositoryId, new ExportOptions
+        {
+            CheckpointKey = "/tmp/linux.gittrace",
+            CheckpointFingerprint = "fingerprint"
+        });
+
+        Assert.True(result.IsSuccess, result.Error);
+        Assert.Equal(0, result.Value.TotalPullRequests);
+        Assert.Equal(0, result.Value.MatchedCount);
+        Assert.Single(timeline.Events);
+        Assert.Null(timeline.Events[0].PullRequest);
+        Assert.Collection(
+            checkpointStore.SavedCheckpoints,
+            checkpoint => Assert.Equal(ExportCheckpointStage.Enriched, checkpoint.Stage));
+    }
+
+    private sealed class NotFoundGitHubEnricher(IExportCheckpointStore checkpointStore)
+        : GitHubEnricher(NullLogger<GitHubEnricher>.Instance, checkpointStore)
+    {
+        protected override Task<IReadOnlyList<PullRequest>> FetchPullRequestsPage(
+            GitHubClient client,
+            RepositoryId repositoryId,
+            int page,
+            CancellationToken cancellationToken)
+            => throw new NotFoundException("repos/torvalds/linux/pulls was not found.", HttpStatusCode.NotFound);
+    }
+
+    private sealed class TestExportCheckpointStore : IExportCheckpointStore
+    {
+        public List<ExportCheckpointState> SavedCheckpoints { get; } = [];
+
+        public Task<ExportCheckpointState?> TryLoad(
+            string checkpointKey,
+            string expectedFingerprint,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<ExportCheckpointState?>(null);
+
+        public Task Save(
+            string checkpointKey,
+            ExportCheckpointState state,
+            CancellationToken cancellationToken = default)
+        {
+            SavedCheckpoints.Add(state);
+            return Task.CompletedTask;
+        }
+
+        public Task AppendPullRequestPatch(
+            string checkpointKey,
+            ExportCheckpointState state,
+            int targetIndex,
+            TraceEvent updatedEvent,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Clear(string checkpointKey, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/src/Cli/Logging/SpectreConsoleLogger.cs
+++ b/src/Cli/Logging/SpectreConsoleLogger.cs
@@ -45,6 +45,8 @@ internal sealed class SpectreConsoleLogger(string categoryName, LogLevel minLeve
             return;
 
         var message = formatter(state, exception);
+        if (exception is not null && logLevel < LogLevel.Error)
+            message = $"{message} ({exception.GetType().Name}: {exception.Message})";
         var shortCategory = categoryName.Split('.').LastOrDefault() ?? categoryName;
 
         var (color, level) = logLevel switch
@@ -61,7 +63,7 @@ internal sealed class SpectreConsoleLogger(string categoryName, LogLevel minLeve
         var markup = $"[grey]{DateTime.Now:HH:mm:ss}[/] [{color}]{level,-5}[/] [grey]{shortCategory}:[/] {Markup.Escape(message)}";
         AnsiConsole.MarkupLine(markup);
 
-        if (exception != null)
+        if (exception != null && logLevel >= LogLevel.Error)
         {
             AnsiConsole.WriteException(exception, ExceptionFormats.ShortenPaths);
         }

--- a/src/GIt/Enrichers/GitHubEnricher.cs
+++ b/src/GIt/Enrichers/GitHubEnricher.cs
@@ -1,12 +1,10 @@
 using ChangeTrace.Configuration.Discovery;
-using ChangeTrace.Core;
 using ChangeTrace.Core.Events;
 using ChangeTrace.Core.Models;
 using ChangeTrace.Core.Results;
 using ChangeTrace.Core.Timelines;
 using ChangeTrace.GIt.Options;
 using ChangeTrace.GIt.Interfaces;
-using ChangeTrace.GIt.Services;
 using ChangeTrace.GIt.Services.Checkpoints.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,7 +22,7 @@ namespace ChangeTrace.GIt.Enrichers;
 /// Handles pagination, API rate limits, and errors gracefully.
 /// </remarks>
 [AutoRegister(ServiceLifetime.Singleton, typeof(IProviderTimelineEnricher))]
-internal sealed class GitHubEnricher(
+internal class GitHubEnricher(
     ILogger<GitHubEnricher> logger,
     IExportCheckpointStore checkpointStore)
     : BasePlatformEnricher(logger), IProviderTimelineEnricher
@@ -84,11 +82,11 @@ internal sealed class GitHubEnricher(
 
                 try
                 {
-                    prs = await client.PullRequest.GetAllForRepository(
-                        repositoryId.Owner,
-                        repositoryId.Name,
-                        new PullRequestRequest { State = ItemStateFilter.All },
-                        new ApiOptions { PageCount = 1, PageSize = 100, StartPage = page });
+                    prs = await FetchPullRequestsPage(
+                        client,
+                        repositoryId,
+                        page,
+                        cancellationToken);
                 }
                 catch (RateLimitExceededException ex)
                 {
@@ -147,10 +145,9 @@ internal sealed class GitHubEnricher(
 
             if (total == 0)
             {
-                if (wasRateLimited)
-                    Logger.LogWarning("GitHub rate limit reached before any PRs could be fetched; skipping PR enrichment.");
-                else
-                    Logger.LogWarning("No PRs found");
+                Logger.LogWarning(wasRateLimited
+                    ? "GitHub rate limit reached before any PRs could be fetched; skipping PR enrichment."
+                    : "No PRs found");
 
                 await SaveSnapshotAsync(
                     options,
@@ -183,8 +180,20 @@ internal sealed class GitHubEnricher(
         }
         catch (NotFoundException ex)
         {
-            Logger.LogError(ex, "Repository not found");
-            return Result<EnrichmentResult>.Failure("Repository not found", ex);
+            Logger.LogWarning(
+                ex,
+                "GitHub pull request data is unavailable for {Repo}; skipping PR enrichment.",
+                repositoryId.FullName);
+
+            await SaveSnapshotAsync(
+                options,
+                timeline,
+                ExportCheckpointStage.Enriched,
+                0,
+                0,
+                cancellationToken);
+
+            return Result<EnrichmentResult>.Success(new EnrichmentResult(0, 0, 0));
         }
         catch (Exception ex)
         {
@@ -205,6 +214,20 @@ internal sealed class GitHubEnricher(
 
         return client;
     }
+
+    /// <summary>
+    /// Fetches one page of GitHub pull requests. Overridable for tests that exercise API failure handling.
+    /// </summary>
+    protected virtual Task<IReadOnlyList<PullRequest>> FetchPullRequestsPage(
+        GitHubClient client,
+        RepositoryId repositoryId,
+        int page,
+        CancellationToken cancellationToken)
+        => client.PullRequest.GetAllForRepository(
+            repositoryId.Owner,
+            repositoryId.Name,
+            new PullRequestRequest { State = ItemStateFilter.All },
+            new ApiOptions { PageCount = 1, PageSize = 100, StartPage = page });
 
     /// <summary>
     /// Attempts to find the timeline event index that matches the given PR via merge SHA, head SHA, or branch name.


### PR DESCRIPTION
## Added Fix

- Regression coverage for GitHub pull request API 404 responses during enrichment.
- A small test seam for GitHub PR page fetching, so the 404 path is covered without network calls.

## Changed

- GitHub PR enrichment now treats `Octokit.NotFoundException` from the pulls API as unavailable enrichment instead of a hard export failure.
- When checkpointing is active, the skipped enrichment path records the stage as `Enriched` so resumable exports do not retry the same unavailable PR sidecar forever.
- Spectre console logging keeps warning-level exceptions concise while preserving full exception rendering for errors and critical failures.

## Result

Exports continue to save the main timeline and supported sidecars for repositories like `torvalds/linux`, even when GitHub PR data is not available.

Fixes #44

## Verification

- `dotnet test Tests/ChangeTrace.Tests.csproj` -> 98 passed, 0 failed