### PR TITLE
Docs: Add structured ADR corpus

### DIFF
--- a/Docs/Adr/README.md
+++ b/Docs/Adr/README.md
@@ -1,0 +1,89 @@
+# Architecture Decision Records
+
+This directory stores ChangeTrace architectural decisions as ADRs. It is not a changelog and not a rewritten commit history. It is a curated set of technical decisions that explains why the system has its current shape and which constraints that imposes on future work.
+
+ADRs are grouped by architecture area. Numbering is global, so a decision ID does not depend on the folder it lives in. Moving a file to another category does not change its number, and the number should be treated as a stable decision identifier.
+
+## How To Read This Collection
+
+Start with the category that matches the area you are changing:
+
+- if the change affects the event model, timelines, or domain contracts, start in `core/`
+- if it affects the `.gittrace` format, DTOs, or disk persistence, go to `persistence/` and `export/`
+- if it affects authentication, workspaces, or hosting providers, read `auth workspace/` and `providers/`
+- if it affects playback, semantic analysis, or rendering, read `player/`, `aggregation/`, `rendering/`, and `graphics/` in that order
+- if it affects application composition and module boundaries, start in `composition/` and `cli/`
+
+Each ADR contains:
+
+- `Context`:
+  the layer and architectural location of the decision
+- `Problem`:
+  the specific technical tension the decision resolves
+- `Decision`:
+  the chosen direction and responsibility boundary
+- `Rejected`:
+  realistic alternatives that were intentionally not selected
+- `Consequences`:
+  maintenance impact, constraints, side effects, and practical implications for future code
+
+## How To Use ADRs During Changes
+
+ADRs do not replace reading the code, but they reduce the cost of understanding decisions that have already been made. When you change a given area:
+
+1. find the matching category
+2. read the 2-4 closest ADRs, not just one
+3. check whether the new change extends the current model or actually breaks it
+4. if a decision is no longer true, add a new ADR instead of silently drifting away from the current direction
+
+This collection is meant to preserve consistency across Core, export, providers, player, and rendering. In ChangeTrace, much of the cost of change comes from contracts between layers rather than from any single class.
+
+## Category Map
+
+The table below shows not only folder names, but also their role in the broader system flow.
+
+| Folder | Scope |
+| --- | --- |
+| [foundation](./foundation/README.md) | Highest-level system and platform assumptions. The starting point for later decisions. |
+| [core](./core/README.md) | Shared domain model: events, timelines, value objects, filters, and Core contracts. |
+| [persistence](./persistence/README.md) | Durable data contracts: `.gittrace`, MessagePack, DTOs, mapping, and I/O. |
+| [composition](./composition/README.md) | Application composition, dependency management, and runtime module boundaries. |
+| [cli](./cli/README.md) | CLI entry layer: command structure, invocation flows, and CLI responsibilities. |
+| [auth-workspace](./auth-workspace/README.md) | Local execution and configuration state: auth, profiles, workspaces, identities, and timeline metadata. |
+| [providers](./providers/README.md) | Hosting-dependent behavior: provider detection, auth flows, enrichment, and fallbacks. |
+| [export](./export/README.md) | Export architecture as a data pipeline: Git backends, sidecars, checkpoints, resume, and artifact persistence. |
+| [player](./player/README.md) | Playback model: time, seeking, playback boundaries, and diagnostics. |
+| [rendering](./rendering/README.md) | Logical visual representation: render commands, scene state, snapshots, layout, and render state. |
+| [graphics](./graphics/README.md) | Execution-time graphics runtime: OpenTK, GPU, buffers, assets, shaders, input, and debug windows. |
+| [aggregation](./aggregation/README.md) | Higher-level models built over TraceEvent: semantics, bundling, coupling, and pull request events. |
+| [diagnostics](./diagnostics/README.md) | Logging rules and the distinction between failure paths and controlled degradation. |
+
+## Relationships Between Categories
+
+The most common architectural flow in ChangeTrace looks like this:
+
+`foundation -> core -> providers/export -> persistence -> player/aggregation/rendering -> graphics`
+
+This is not a strict dependency diagram of the project, but it is a useful map for reading decisions. In practice:
+
+- `core/` defines what the system considers to be data and events
+- `providers/` and `export/` define how that data is gathered and enriched
+- `persistence/` defines how export output is stored
+- `player/` and `aggregation/` prepare data for playback and interpretation
+- `rendering/` and `graphics/` turn it into visual state and an executable rendering runtime
+
+## When To Add A New ADR
+
+A new ADR is worth adding when a change:
+
+- shifts responsibility boundaries between layers
+- introduces a new data contract or a new durable artifact
+- changes the execution model of export, playback, or rendering
+- adds a new provider specific behavior that no longer fits the current model
+- replaces an earlier decision with a different conscious trade off
+
+It is usually not worth adding an ADR for:
+
+- an ordinary refactor without an architectural change in direction
+- a cosmetic local API change limited to one file or class
+- a documentation or test only adjustment that does not change system contracts

--- a/Docs/Adr/aggregation/054-model-pull-requests-as-semantic-events.md
+++ b/Docs/Adr/aggregation/054-model-pull-requests-as-semantic-events.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](062-aggregate-commit-bundles-explicitly.md)
+
+## [054] Model Pull Requests As Semantic Events
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Pull request data enters the system as enrichment attached to commits and sidecars, but later consumers do not work well against provider payloads directly. Rendering and analysis need one stable representation for review activity, merge intent, and PR lifecycle.
+
+**Problem:**
+
+A pull request spans multiple commits and often multiple branches, but raw timeline events expose only the low level pieces. If each consumer has to reconstruct PR identity and lifecycle independently, the repository accumulates duplicate provider specific logic and inconsistent behavior.
+
+**Decision:**
+
+Pull requests are elevated into dedicated semantic events produced by aggregation. The aggregator correlates enriched commit data into a PR level representation that downstream consumers can render, filter, and analyze without redoing provider specific correlation work.
+
+**Rejected:**
+
+- Treating pull requests only as commit attached metadata enrichment.
+- Letting the renderer infer pull request structure heuristically from commit sequences.
+- Repeating provider specific PR correlation logic in each analytical consumer.
+- Extending the base event model until it directly carries provider review semantics.
+
+**Consequences:**
+
+Pull request visualization and analysis now share one semantic contract instead of several local heuristics. The tradeoff is that PR identity, merge semantics, and enrichment compatibility have to remain stable at the aggregation boundary.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](062-aggregate-commit-bundles-explicitly.md)

--- a/Docs/Adr/aggregation/062-aggregate-commit-bundles-explicitly.md
+++ b/Docs/Adr/aggregation/062-aggregate-commit-bundles-explicitly.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](054-model-pull-requests-as-semantic-events.md) | [Next](063-aggregate-file-coupling-explicitly.md)
+
+## [062] Aggregate Commit Bundles Explicitly
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Large repositories often produce bursts of commit activity that read as one episode of work rather than as dozens of isolated points. The raw timeline must preserve individual commits, but rendering and higher level analysis need a reusable grouped view for dense activity.
+
+**Problem:**
+
+Rendering every commit independently can flood the scene with short lived noise during rebases, automated churn, or concentrated feature work. If grouping happens only inside the renderer, the logic becomes hard to test and other consumers cannot reuse the same interpretation.
+
+**Decision:**
+
+Related commits are grouped by a dedicated aggregator that emits bundle level activity units on top of the base stream. Consumers can opt into those grouped events without losing access to the original commit level history.
+
+**Rejected:**
+
+- Always rendering every commit as a separate unit.
+- Deferring grouping until the presentation layer.
+- Collapsing commit bursts destructively inside the persisted base timeline.
+- Hard coding one renderer specific bundling rule set with no reusable analytical representation.
+
+**Consequences:**
+
+Busy repositories become easier to read, and bundling policy can be tested outside graphics code. The cost is that grouping rules become an architectural contract: if they are too aggressive, meaningful commit level transitions disappear for every consumer using the bundled view.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](054-model-pull-requests-as-semantic-events.md) | [Next](063-aggregate-file-coupling-explicitly.md)

--- a/Docs/Adr/aggregation/063-aggregate-file-coupling-explicitly.md
+++ b/Docs/Adr/aggregation/063-aggregate-file-coupling-explicitly.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](062-aggregate-commit-bundles-explicitly.md) | [Next](064-use-semantic-aggregation-before-rendering.md)
+
+## [063] Aggregate File Coupling Explicitly
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+File coupling is not a first class concept in the raw timeline. It has to be derived by correlating files that repeatedly change together across many commits, and the resulting relationship is useful to both analytics and visualization.
+
+**Problem:**
+
+Relationships between files changed together are analytical information that is distinct from individual commits. If coupling is computed ad hoc in one view or renderer, each consumer pays the scan cost separately and may disagree about what counts as a meaningful relationship.
+
+**Decision:**
+
+File coupling is computed by a dedicated aggregator that scans the event stream and emits reusable co change relationships. Consumers work with an already derived coupling model instead of rebuilding file relationship statistics on their own.
+
+**Rejected:**
+
+- Computing coupling ad hoc in a single view.
+- Leaving file relationships implicit and never modeling them explicitly.
+- Rebuilding co change statistics inside rendering or export consumers whenever they need them.
+- Storing coupling only as mutable renderer state with no analytical representation outside graphics.
+
+**Consequences:**
+
+File relationship analysis becomes reusable across features and can evolve independently from views. The downside is that coupling computation can be expensive on large histories, so thresholds, memory behavior, and benchmark coverage become part of the aggregator contract.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](062-aggregate-commit-bundles-explicitly.md) | [Next](064-use-semantic-aggregation-before-rendering.md)

--- a/Docs/Adr/aggregation/064-use-semantic-aggregation-before-rendering.md
+++ b/Docs/Adr/aggregation/064-use-semantic-aggregation-before-rendering.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](063-aggregate-file-coupling-explicitly.md)
+
+## [064] Use Semantic Aggregation Before Rendering
+
+*2026-03* | Status: accepted
+
+**Context:**
+
+The rendering layer translates repository activity into scene state, but it is not the right place to infer every higher order concept from raw commit and file events. Semantic aggregation provides an intermediate boundary where low level history becomes domain relevant episodes that rendering can consume directly.
+
+**Problem:**
+
+The renderer needs higher level events than isolated file changes and raw commits. If every translator has to reconstruct semantic episodes independently, rendering becomes coupled to analytical policy and small interpretation changes become expensive to coordinate.
+
+**Decision:**
+
+Aggregators build semantic events before the rendering stage. The rendering pipeline consumes that prepared semantic stream instead of deriving higher order meaning on demand from raw timeline events.
+
+**Rejected:**
+
+- Every translator deriving semantics on its own.
+- Extending `TraceEvent` with every analytical view.
+- Passing only raw commit and file events into rendering and inferring the rest there.
+- Treating semantic aggregation as a renderer local optimization instead of a reusable analytical stage.
+
+**Consequences:**
+
+Rendering receives richer, policy backed inputs and can stay focused on visual translation rather than historical inference. The cost is that aggregation becomes a hard behavioral boundary: changing semantic event rules can change rendering output even when no graphics code changes.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](063-aggregate-file-coupling-explicitly.md)

--- a/Docs/Adr/aggregation/README.md
+++ b/Docs/Adr/aggregation/README.md
@@ -1,0 +1,26 @@
+[ADR Home](../README.md)
+
+# aggregation
+
+This category describes higher level semantic event models built on top of TraceEvent.
+
+## Scope
+
+Look here for bundling, coupling, pull request semantics, and other aggregate event models that sit above raw trace events.
+
+## Responsibility Boundaries
+
+Aggregation enriches meaning before later layers consume it. It should not become a rendering or persistence layer by itself.
+
+## How To Start Reading
+
+Start here when changing semantic event derivation or higher level event grouping.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [054-model-pull-requests-as-semantic-events.md](./054-model-pull-requests-as-semantic-events.md) | Model Pull Requests As Semantic Events |
+| [062-aggregate-commit-bundles-explicitly.md](./062-aggregate-commit-bundles-explicitly.md) | Aggregate Commit Bundles Explicitly |
+| [063-aggregate-file-coupling-explicitly.md](./063-aggregate-file-coupling-explicitly.md) | Aggregate File Coupling Explicitly |
+| [064-use-semantic-aggregation-before-rendering.md](./064-use-semantic-aggregation-before-rendering.md) | Use Semantic Aggregation Before Rendering |

--- a/Docs/Adr/auth-workspace/028-keep-authentication-in-credentialtrace.md
+++ b/Docs/Adr/auth-workspace/028-keep-authentication-in-credentialtrace.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](029-support-local-auth-sessions.md)
+
+## [028] Keep Authentication In Credentialtrace
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+Authentication state is reused across export, enrichment, and workspace oriented commands, but it is not part of timeline construction itself. The system needs one place that owns provider definitions, sessions, and token persistence without pushing those concerns into export orchestration or rendering.
+
+**Problem:**
+
+Without a dedicated auth module, access tokens tend to get threaded through command handlers, exporter entry points, and provider clients as parameters. That makes session reuse awkward, spreads security sensitive logic across unrelated layers, and makes it hard to restore a consistent local auth context between commands.
+
+**Decision:**
+
+Auth flows, sessions, tokens, and providers live in the `CredentialTrace` module. Export and workspace code consume auth state through contracts instead of owning token lifecycle or provider specific session behavior directly.
+
+**Rejected:**
+
+- Keeping authentication logic inside the exporter.
+- Passing tokens through every layer as call parameters.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+Export consumes sessions through contracts, and auth reuse becomes simpler across commands. The tradeoff is that `CredentialTrace` becomes a security sensitive module whose storage format, migrations, and provider session behavior must be maintained carefully.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](029-support-local-auth-sessions.md)

--- a/Docs/Adr/auth-workspace/029-support-local-auth-sessions.md
+++ b/Docs/Adr/auth-workspace/029-support-local-auth-sessions.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](028-keep-authentication-in-credentialtrace.md) | [Next](030-use-encrypted-local-token-storage.md)
+
+## [029] Support Local Auth Sessions
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This category concerns everything that forms durable local execution context: from auth sessions and profiles to the place where the timeline is stored. This is not a CLI ergonomics detail, but a real local storage contract.
+
+**Problem:**
+
+The calling layer should not require the token to be entered again for every export.
+This group of decisions defines the local execution state: sessions, profiles, identities, active workspace context, and the physical location of stored timelines.
+
+**Decision:**
+
+Auth sessions are persisted locally and can be reused.
+Authentication and workspace state are not an export detail; they form a separate layer responsible for restoring local working context between application runs.
+
+**Rejected:**
+
+- Passing the token only as a CLI argument.
+- A remote ChangeTrace session backend.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+The authorization flow becomes shorter, but local auth files require protection.
+Local storage becomes part of the system contract, so its consistency, migrations, and security have to be maintained carefully.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](028-keep-authentication-in-credentialtrace.md) | [Next](030-use-encrypted-local-token-storage.md)

--- a/Docs/Adr/auth-workspace/030-use-encrypted-local-token-storage.md
+++ b/Docs/Adr/auth-workspace/030-use-encrypted-local-token-storage.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](029-support-local-auth-sessions.md) | [Next](034-model-organizations-separately-from-workspaces.md)
+
+## [030] Use Encrypted Local Token Storage
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This category concerns everything that forms durable local execution context: from auth sessions and profiles to the place where the timeline is stored. This is not a CLI ergonomics detail, but a real local storage contract.
+
+**Problem:**
+
+Provider tokens should not be stored in plain text files.
+This group of decisions defines the local execution state: sessions, profiles, identities, active workspace context, and the physical location of stored timelines.
+
+**Decision:**
+
+The token store encrypts tokens and hardens auth files.
+Authentication and workspace state are not an export detail; they form a separate layer responsible for restoring local working context between application runs.
+
+**Rejected:**
+
+- Plaintext `auth.json`.
+- No session persistence and forced login on every use.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+The risk of accidental leakage is reduced, but this is not a full OS keychain.
+Local storage becomes part of the system contract, so its consistency, migrations, and security have to be maintained carefully.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](029-support-local-auth-sessions.md) | [Next](034-model-organizations-separately-from-workspaces.md)

--- a/Docs/Adr/auth-workspace/034-model-organizations-separately-from-workspaces.md
+++ b/Docs/Adr/auth-workspace/034-model-organizations-separately-from-workspaces.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](030-use-encrypted-local-token-storage.md) | [Next](035-persist-active-workspace-context.md)
+
+## [034] Model Organizations Separately From Workspaces
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The local workspace model has to represent both who owns a repository and where the operator is currently working. Provider organizations and local workspaces overlap, but they do not mean the same thing, and treating them as one concept makes local state harder to manage as the number of repositories grows.
+
+**Problem:**
+
+Repositories are naturally grouped by organization, but operators also need a local boundary for selecting active context, storing timelines, and reusing settings across commands. A single flat project catalog does not capture that distinction, and using provider organization as the only grouping model leaks remote host assumptions into local storage.
+
+**Decision:**
+
+Organizations and workspaces are modeled as separate local profiles. Organizations represent ownership boundaries, while workspaces represent the operator's local working boundary and active context.
+
+**Rejected:**
+
+- One flat catalog of projects.
+- Using the provider organization as the only local model.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+The local model matches repository ownership and operator context more closely, which makes navigation and persistence behavior easier to reason about. The cost is additional metadata and one more layer of local indirection that storage and migration code must keep consistent.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](030-use-encrypted-local-token-storage.md) | [Next](035-persist-active-workspace-context.md)

--- a/Docs/Adr/auth-workspace/035-persist-active-workspace-context.md
+++ b/Docs/Adr/auth-workspace/035-persist-active-workspace-context.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](034-model-organizations-separately-from-workspaces.md) | [Next](036-use-ulid-for-local-identities.md)
+
+## [035] Persist Active Workspace Context
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+Export, playback, and repository commands often target the same workspace across multiple runs. The system already persists related local state such as profiles and sessions, so workspace selection needs the same durability if commands are to operate against one consistent local context.
+
+**Problem:**
+
+Export and playback should be able to reuse the current workspace without requiring the caller to repeat organization and workspace arguments on every command. If active workspace selection is transient, command behavior becomes harder to predict and higher level flows must keep reconstructing context that the local environment already knows.
+
+**Decision:**
+
+The active workspace is persisted as part of local execution state. Workspace selection lives alongside related local auth and profile state so that application runs can restore one coherent working context.
+
+**Rejected:**
+
+- Requiring `org` and `workspace` in every command.
+- Keeping context only in process memory.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+Commands can default to a stable workspace context without repeated selection arguments. The tradeoff is that the stored context becomes part of the durable local contract, so visibility, consistency, migration, and reset behavior have to stay explicit.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](034-model-organizations-separately-from-workspaces.md) | [Next](036-use-ulid-for-local-identities.md)

--- a/Docs/Adr/auth-workspace/036-use-ulid-for-local-identities.md
+++ b/Docs/Adr/auth-workspace/036-use-ulid-for-local-identities.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](035-persist-active-workspace-context.md) | [Next](090-store-workspace-timelines-with-metadata.md)
+
+## [036] Use ULID For Local Identities
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This category concerns everything that forms durable local execution context: from auth sessions and profiles to the place where the timeline is stored. This is not a CLI ergonomics detail, but a real local storage contract.
+
+**Problem:**
+
+Profiles, workspaces, and exports need stable local identifiers.
+This group of decisions defines the local execution state: sessions, profiles, identities, active workspace context, and the physical location of stored timelines.
+
+**Decision:**
+
+Local identifiers use ULID.
+Authentication and workspace state are not an export detail; they form a separate layer responsible for restoring local working context between application runs.
+
+**Rejected:**
+
+- Random unreadable GUIDs everywhere.
+- Identifying everything only through logical names.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+Identifiers are stable and time sortable, but they require serializers and converters.
+Local storage becomes part of the system contract, so its consistency, migrations, and security have to be maintained carefully.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](035-persist-active-workspace-context.md) | [Next](090-store-workspace-timelines-with-metadata.md)

--- a/Docs/Adr/auth-workspace/090-store-workspace-timelines-with-metadata.md
+++ b/Docs/Adr/auth-workspace/090-store-workspace-timelines-with-metadata.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](036-use-ulid-for-local-identities.md)
+
+## [090] Store Workspace Timelines With Metadata
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Workspace exports are not useful if the timeline artifact can only be loaded by remembering its exact file path manually. Once timelines are stored under a workspace, the local store also needs enough adjacent metadata to support listing, discovery, and later selection.
+
+**Problem:**
+
+A timeline persisted in a workspace should remain discoverable and describable after the export command completes. If only the `.gittrace` payload is stored, later commands have to infer identity, provenance, and presentation details from file names or ad hoc scanning rules.
+
+**Decision:**
+
+Workspace export persists the `.gittrace` artifact together with adjacent metadata that describes the stored timeline. Timeline storage is treated as a local workspace contract rather than just a file drop performed by export.
+
+**Rejected:**
+
+- Only `.gittrace` files without an index.
+- One global timeline directory with no workspace partitioning.
+- Splitting auth and workspace state across unrelated and uncoordinated storage locations.
+- Keeping local context only in process memory or only in CLI arguments.
+
+**Consequences:**
+
+Workspace playback and timeline listing can rely on explicit stored metadata instead of reconstructing context from file layout alone. The tradeoff is that metadata becomes part of the durable local contract and must stay in sync when timelines are moved, replaced, or migrated.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](036-use-ulid-for-local-identities.md)

--- a/Docs/Adr/auth-workspace/README.md
+++ b/Docs/Adr/auth-workspace/README.md
@@ -1,0 +1,29 @@
+[ADR Home](../README.md)
+
+# auth workspace
+
+This category captures authentication, profiles, workspaces, and local execution state persisted between runs.
+
+## Scope
+
+Look here for auth sessions, token storage, profile/workspace modeling, active context persistence, and workspace timeline storage.
+
+## Responsibility Boundaries
+
+This layer owns local operational state. It should not redefine timeline semantics or export execution.
+
+## How To Start Reading
+
+Start here when changing local auth, workspace context, or persisted operator state.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [028-keep-authentication-in-credentialtrace.md](./028-keep-authentication-in-credentialtrace.md) | Keep Authentication In Credentialtrace |
+| [029-support-local-auth-sessions.md](./029-support-local-auth-sessions.md) | Support Local Auth Sessions |
+| [030-use-encrypted-local-token-storage.md](./030-use-encrypted-local-token-storage.md) | Use Encrypted Local Token Storage |
+| [034-model-organizations-separately-from-workspaces.md](./034-model-organizations-separately-from-workspaces.md) | Model Organizations Separately From Workspaces |
+| [035-persist-active-workspace-context.md](./035-persist-active-workspace-context.md) | Persist Active Workspace Context |
+| [036-use-ulid-for-local-identities.md](./036-use-ulid-for-local-identities.md) | Use ULID For Local Identities |
+| [090-store-workspace-timelines-with-metadata.md](./090-store-workspace-timelines-with-metadata.md) | Store Workspace Timelines With Metadata |

--- a/Docs/Adr/cli/027-separate-cli-syntax-from-command-handling.md
+++ b/Docs/Adr/cli/027-separate-cli-syntax-from-command-handling.md
@@ -1,0 +1,31 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](031-use-nested-command-groups-for-user-workflows.md)
+
+## [027] Separate CLI Syntax From Command Handling
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The CLI defines the public entry points into export, auth, playback, and related workflows, but it is not the right place to absorb application logic. As command coverage grows, the boundary between parsing/orchestration and execution needs to stay explicit.
+
+**Problem:**
+
+If command definitions also implement execution logic, parsing concerns, dependency wiring, and application behavior collapse into the same layer. That makes commands harder to test, encourages duplication, and turns the CLI surface into the place where unrelated workflow rules accumulate.
+
+**Decision:**
+
+Each command has a separate handler that performs the work.
+The CLI remains a thin orchestration layer: it defines how work enters the system, but it does not take ownership of export, auth, or rendering logic.
+
+**Rejected:**
+
+- Keeping application logic directly inside command definitions.
+- One handler for many unrelated commands.
+- Extending the CLI through special cases instead of one command and handler convention.
+- Treating commands as thin only in name while continuing to add application logic into them.
+
+**Consequences:**
+
+The CLI stays easier to test and extend because syntax and execution evolve independently. The tradeoff is that command/handler pairs become an architectural convention that must be maintained consistently instead of bypassed for convenience.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](031-use-nested-command-groups-for-user-workflows.md)

--- a/Docs/Adr/cli/031-use-nested-command-groups-for-user-workflows.md
+++ b/Docs/Adr/cli/031-use-nested-command-groups-for-user-workflows.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](027-separate-cli-syntax-from-command-handling.md) | [Next](089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md)
+
+## [031] Use Nested Command Groups For Related CLI Workflows
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions keep the CLI as a predictable entry layer rather than a collection of accidental commands. The focus is on syntax consistency, stable entry points, and maintaining a thin orchestration layer.
+
+**Problem:**
+
+Auth, organizations, and workspaces have a natural hierarchy that should be visible in the CLI.
+The concern is not only argument parsing, but preserving a stable execution model as the system grows.
+
+**Decision:**
+
+The CLI uses command groups such as `auth`, `org`, and `workspace`.
+The CLI remains a thin orchestration layer: it defines how work enters the system, but it does not take ownership of export, auth, or rendering logic.
+
+**Rejected:**
+
+- One flat list of all commands.
+- Packing multiple control flows into the options of one command.
+- Extending the CLI through special cases instead of one command and handler convention.
+- Treating commands as thin only in name while continuing to add application logic into them.
+
+**Consequences:**
+
+Command hierarchy reflects domain structure, but naming and aliases must stay consistent.
+Commands can grow with the system without turning `Program.cs` into a monolith, but the command/handler convention has to be maintained consistently.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](027-separate-cli-syntax-from-command-handling.md) | [Next](089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md)

--- a/Docs/Adr/cli/089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md
+++ b/Docs/Adr/cli/089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](031-use-nested-command-groups-for-user-workflows.md)
+
+## [089] Keep Interactive CLI Decisions In Dedicated Prompt Components
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The CLI layer contains dedicated prompt components such as `EnrichmentPrompt`, `MergeDetectionPrompt`, and `ProviderPrompt`, instead of pushing interactive question logic directly into export handlers, auth handlers, and workspace workflows.
+
+**Problem:**
+
+Interactive choice of provider, enrichment, or merge detection is a separate responsibility from command execution. When a handler both asks for parameters, validates input, and triggers application logic, the boundary between CLI syntax and system behavior quickly becomes blurred.
+
+**Decision:**
+
+Interactive decisions stay in dedicated prompt layer components, and handlers consume already resolved options. The CLI keeps a separate layer for collecting execution time decisions instead of mixing that concern with export, auth, and provider aware execution logic.
+
+**Rejected:**
+
+- Asking interactive questions directly inside command handlers.
+- Hiding every choice behind arguments only, with no interactive layer available.
+- Duplicating prompt logic across multiple commands instead of maintaining shared components.
+- Treating interactive input as a detail of provider or export layers.
+
+**Consequences:**
+
+The CLI remains clearer and interactive modes are easier to evolve without contaminating handlers. The drawback is that the prompt layer becomes its own contract, which must stay aligned with command options and workflow changes.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](031-use-nested-command-groups-for-user-workflows.md)

--- a/Docs/Adr/cli/README.md
+++ b/Docs/Adr/cli/README.md
@@ -1,0 +1,25 @@
+[ADR Home](../README.md)
+
+# cli
+
+This category describes decisions about CLI architecture and command workflows.
+
+## Scope
+
+Look here for command/handler separation, command groups, prompt components, terminal ergonomics, and the point where the CLI stops being a mere input layer.
+
+## Responsibility Boundaries
+
+The CLI should not absorb export, auth, or rendering logic. It is a thin orchestration and operator interaction layer.
+
+## How To Start Reading
+
+Start here when adding commands or changing interactive command flows.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [027-separate-cli-syntax-from-command-handling.md](./027-separate-cli-syntax-from-command-handling.md) | Separate CLI Syntax From Command Handling |
+| [031-use-nested-command-groups-for-user-workflows.md](./031-use-nested-command-groups-for-user-workflows.md) | Use Nested Command Groups For Related CLI Workflows |
+| [089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md](./089-keep-interactive-cli-decisions-in-dedicated-prompt-components.md) | Keep Interactive CLI Decisions In Dedicated Prompt Components |

--- a/Docs/Adr/composition/024-compose-services-through-dependency-injection.md
+++ b/Docs/Adr/composition/024-compose-services-through-dependency-injection.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](025-register-services-through-explicit-discovery-markers.md)
+
+## [024] Compose Services Through Dependency Injection
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define how the application composes dependencies and where the boundary sits between a service implementation and the way it is provided to runtime. The goal is to reduce manual wiring and keep responsibility boundaries readable.
+
+**Problem:**
+
+A growing number of services requires a controlled dependency graph.
+Without this decision, dependencies would quickly start being assembled manually in many places, and modules would lose clear responsibility boundaries.
+
+**Decision:**
+
+The application uses Microsoft dependency injection and central initialization.
+Choosing DI and discovery means application composition is treated as a separate startup responsibility rather than a detail of handlers or domain services.
+
+**Rejected:**
+
+- Static singletons.
+- Manually constructing objects in each handler.
+- A mixed model in which some services are composed through DI and others through manual singletons.
+- Initializing dependencies only at call sites instead of in one composition root.
+
+**Consequences:**
+
+Modules are testable, but service registration and lifetimes must be maintained consistently.
+This improves testability and implementation swapability, but it requires disciplined registration, lifetimes, and clear contracts between modules.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](025-register-services-through-explicit-discovery-markers.md)

--- a/Docs/Adr/composition/025-register-services-through-explicit-discovery-markers.md
+++ b/Docs/Adr/composition/025-register-services-through-explicit-discovery-markers.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](024-compose-services-through-dependency-injection.md)
+
+## [025] Register Services Through Explicit Discovery Markers
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define how the application composes dependencies and where the boundary sits between a service implementation and the way it is provided to runtime. The goal is to reduce manual wiring and keep responsibility boundaries readable.
+
+**Problem:**
+
+Manually registering every service quickly increases boilerplate.
+Without this decision, dependencies would quickly start being assembled manually in many places, and modules would lose clear responsibility boundaries.
+
+**Decision:**
+
+Services can be registered through discovery attributes when that fits the module.
+Choosing DI and discovery means application composition is treated as a separate startup responsibility rather than a detail of handlers or domain services.
+
+**Rejected:**
+
+- Fully manual registration of everything.
+- Magic scanning without explicit markers.
+- A mixed model in which some services are composed through DI and others through manual singletons.
+- Initializing dependencies only at call sites instead of in one composition root.
+
+**Consequences:**
+
+Adding services becomes simpler, but a missing attribute can mean a missing runtime service.
+This improves testability and implementation swapability, but it requires disciplined registration, lifetimes, and clear contracts between modules.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](024-compose-services-through-dependency-injection.md)

--- a/Docs/Adr/composition/README.md
+++ b/Docs/Adr/composition/README.md
@@ -1,0 +1,24 @@
+[ADR Home](../README.md)
+
+# composition
+
+This category describes how the application is assembled from runtime services and modules.
+
+## Scope
+
+Look here for dependency registration, service discovery, composition roots, and module wiring.
+
+## Responsibility Boundaries
+
+Composition wires the system together but should not absorb domain, export, or rendering logic.
+
+## How To Start Reading
+
+Start here when changing service registration, dependency discovery, or runtime assembly boundaries.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [024-compose-services-through-dependency-injection.md](./024-compose-services-through-dependency-injection.md) | Compose Services Through Dependency Injection |
+| [025-register-services-through-explicit-discovery-markers.md](./025-register-services-through-explicit-discovery-markers.md) | Register Services Through Explicit Discovery Markers |

--- a/Docs/Adr/core/003-keep-filtering-behind-specifications.md
+++ b/Docs/Adr/core/003-keep-filtering-behind-specifications.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](004-keep-the-domain-model-independent-from-git-providers.md)
+
+## [003] Keep Filtering Behind Specifications
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Timeline filtering appears in many places and is easy to duplicate.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Filtering rules are modeled as specifications and domain queries.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Duplicating LINQ predicates in handlers.
+- Publicly persisting experimental filters.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+Filters are composable, but they must keep up with changes in the event model.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](004-keep-the-domain-model-independent-from-git-providers.md)

--- a/Docs/Adr/core/004-keep-the-domain-model-independent-from-git-providers.md
+++ b/Docs/Adr/core/004-keep-the-domain-model-independent-from-git-providers.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](003-keep-filtering-behind-specifications.md) | [Next](005-represent-identifiers-as-value-objects.md)
+
+## [004] Keep The Domain Model Independent From Git Providers
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Repository history comes from Git, but ChangeTrace analysis should not depend on GitHub, GitLab, or Codeberg.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Core describes the repository through its own domain types, events, timeline structures, and value objects, without dependencies on provider APIs.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- A domain model built directly on provider responses.
+- Using raw Git records as the application's public model.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+Core can be used by export, the player, and rendering, while provider specific data is isolated in enrichment or sidecars.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](003-keep-filtering-behind-specifications.md) | [Next](005-represent-identifiers-as-value-objects.md)

--- a/Docs/Adr/core/005-represent-identifiers-as-value-objects.md
+++ b/Docs/Adr/core/005-represent-identifiers-as-value-objects.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](004-keep-the-domain-model-independent-from-git-providers.md) | [Next](006-track-branch-lifecycle-explicitly.md)
+
+## [005] Represent Identifiers As Value Objects
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Actor names, file paths, SHAs, branches, and repositories are semantically different even though they are often represented as strings.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Domain identifiers are represented by explicit value types instead of primitives.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Passing raw strings through every layer.
+- Validating meaning only at the usage sites.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+The code becomes more self documenting and type safe, but serialization and tests must handle these types explicitly.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](004-keep-the-domain-model-independent-from-git-providers.md) | [Next](006-track-branch-lifecycle-explicitly.md)

--- a/Docs/Adr/core/006-track-branch-lifecycle-explicitly.md
+++ b/Docs/Adr/core/006-track-branch-lifecycle-explicitly.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](005-represent-identifiers-as-value-objects.md) | [Next](007-use-result-types-for-recoverable-domain-operations.md)
+
+## [006] Track Branch Lifecycle Explicitly
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Branches change state over time and cannot be visualized correctly from individual commits alone.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Branch lifecycle is maintained through dedicated tracking logic.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Treating branches as simple labels.
+- Reconstructing branch state only in the renderer.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+The timeline carries richer branch context, but correct branch tracking requires dedicated test coverage.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](005-represent-identifiers-as-value-objects.md) | [Next](007-use-result-types-for-recoverable-domain-operations.md)

--- a/Docs/Adr/core/007-use-result-types-for-recoverable-domain-operations.md
+++ b/Docs/Adr/core/007-use-result-types-for-recoverable-domain-operations.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](006-track-branch-lifecycle-explicitly.md) | [Next](008-keep-unstable-query-apis-internal.md)
+
+## [007] Use Result Types For Recoverable Domain Operations
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Some domain operations can fail in predictable ways and should not be modeled only with exceptions.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Controlled failures use `Result` and `Result<T>` types.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Using exceptions as the only error flow mechanism.
+- Returning nulls or magic values.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+Domain failures become more explicit, but callers must handle the result instead of assuming success.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](006-track-branch-lifecycle-explicitly.md) | [Next](008-keep-unstable-query-apis-internal.md)

--- a/Docs/Adr/core/008-keep-unstable-query-apis-internal.md
+++ b/Docs/Adr/core/008-keep-unstable-query-apis-internal.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](007-use-result-types-for-recoverable-domain-operations.md) | [Next](009-build-timelines-through-a-dedicated-builder.md)
+
+## [008] Keep Unstable Query Apis Internal
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Early analytical queries changed quickly and should not freeze a public API too soon.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Immature specifications and helpers remain internal until their contracts are stable.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- A public API for every experimental rule.
+- No dedicated query layer at all.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+The project can refactor analytical queries without incurring public compatibility costs.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](007-use-result-types-for-recoverable-domain-operations.md) | [Next](009-build-timelines-through-a-dedicated-builder.md)

--- a/Docs/Adr/core/009-build-timelines-through-a-dedicated-builder.md
+++ b/Docs/Adr/core/009-build-timelines-through-a-dedicated-builder.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](008-keep-unstable-query-apis-internal.md) | [Next](010-model-repository-activity-as-trace-events.md)
+
+## [009] Build Timelines Through A Dedicated Builder
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Converting Git history into a timeline requires consistent ordering of commits, branches, files, and statistics.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+The timeline is built through a dedicated `TimelineBuilder`, not inside the Git reader or the renderer.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Building the timeline separately in each consumer.
+- Combining Git reading with event interpretation.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+Timeline logic becomes testable and easier to optimize, but it also becomes a central change point.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](008-keep-unstable-query-apis-internal.md) | [Next](010-model-repository-activity-as-trace-events.md)

--- a/Docs/Adr/core/010-model-repository-activity-as-trace-events.md
+++ b/Docs/Adr/core/010-model-repository-activity-as-trace-events.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](009-build-timelines-through-a-dedicated-builder.md) | [Next](011-optimize-timeline-builder-hot-paths.md)
+
+## [010] Model Repository Activity As Trace Events
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Different parts of the application need a shared language for describing repository activity.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+Repository activity is represented as `TraceEvent` instances with explicit domain metadata.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Separate event models for CLI, export, and rendering.
+- Direct use of raw Git history records.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+`TraceEvent` becomes a central system contract and requires careful evolution when format or aggregation changes.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](009-build-timelines-through-a-dedicated-builder.md) | [Next](011-optimize-timeline-builder-hot-paths.md)

--- a/Docs/Adr/core/011-optimize-timeline-builder-hot-paths.md
+++ b/Docs/Adr/core/011-optimize-timeline-builder-hot-paths.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](010-model-repository-activity-as-trace-events.md) | [Next](065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md)
+
+## [011] Optimize Timeline Builder Hot Paths
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+This decision concerns the language the system uses to describe the repository and its history. It is the layer used by export, the player, aggregation, and rendering, so its goal is not the convenience of one module but a shared and stable model for all of them.
+
+**Problem:**
+
+Timeline building runs for every export and can dominate the cost of large repositories.
+In practice, the goal is to prevent raw Git history from leaking into other layers as an unstructured set of strings, dates, and ad hoc structures.
+
+**Decision:**
+
+`TimelineBuilder` hot paths are optimized and measured.
+The responsibility boundary here runs between the domain model and infrastructure: export, providers, the player, and rendering consume the established model instead of defining it independently.
+
+**Rejected:**
+
+- Accepting a slow builder as an unavoidable domain cost.
+- Micro optimizations without measurement.
+- Reinterpreting the domain model locally in each layer.
+- A hybrid in which part of the meaning remains in Core and part in infrastructure or the presentation layer.
+
+**Consequences:**
+
+Export becomes faster, but hot path code can be less straightforward and requires benchmarks.
+This decision shapes contracts across many modules, so every change in Core requires attention to compatibility and the refactoring cost outside the core itself.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](010-model-repository-activity-as-trace-events.md) | [Next](065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md)

--- a/Docs/Adr/core/065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md
+++ b/Docs/Adr/core/065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](011-optimize-timeline-builder-hot-paths.md)
+
+## [065] Use A Reuareble Aggregation Engine For Streaming Semantic Processing
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The `Core.Aggregators` layer is not limited to individual classes such as `CommitBundlingAggregator` or `PullRequestAggregator`. Above them sits a shared `EventAggregationEngine<TIn>` that maintains a consistent model of streaming processing, batching, flushing, and disposal for semantic aggregators.
+
+**Problem:**
+
+Aggregators share a lifecycle: they accept events sequentially, sometimes operate on a single stream, sometimes on a batch, and require explicit flushing. If each aggregation stage implements that model on its own, it is easy for the semantics of `Process`, `Flush`, and `Dispose` to drift apart, which then leaks into export and rendering.
+
+**Decision:**
+
+Core maintains a reusable aggregation engine that orchestrates aggregator execution and separates streaming semantics from the specific domain logic of each aggregator. Aggregators define only semantic transformation, not their own execution framework.
+
+**Rejected:**
+
+- Manually calling `Process` and `Flush` for every aggregator at every call site.
+- Separate aggregation loops for export, rendering, and other consumers.
+- Embedding batching logic and disposal directly in individual aggregators.
+- Treating aggregation as a one off helper for one pipeline instead of a Core contract.
+
+**Consequences:**
+
+Aggregation semantics become more predictable and reusable across different system layers. The cost is an additional core abstraction that must remain simple enough not to hide important differences between domain aggregation stages.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](011-optimize-timeline-builder-hot-paths.md)

--- a/Docs/Adr/core/README.md
+++ b/Docs/Adr/core/README.md
@@ -1,0 +1,32 @@
+[ADR Home](../README.md)
+
+# core
+
+This category describes the domain core: events, timelines, value objects, filters, and Core responsibility boundaries.
+
+## Scope
+
+Look here for questions about what the system considers to be primary data and how the shared model is defined for export, player, aggregation, and rendering.
+
+## Responsibility Boundaries
+
+Core should not depend on a specific provider, storage backend, or GPU runtime. It is the meaning of the data, not an integration layer.
+
+## How To Start Reading
+
+Start here when changing TraceEvent, timelines, domain identifiers, or filtering rules.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [003-keep-filtering-behind-specifications.md](./003-keep-filtering-behind-specifications.md) | Keep Filtering Behind Specifications |
+| [004-keep-the-domain-model-independent-from-git-providers.md](./004-keep-the-domain-model-independent-from-git-providers.md) | Keep The Domain Model Independent From Git Providers |
+| [005-represent-identifiers-as-value-objects.md](./005-represent-identifiers-as-value-objects.md) | Represent Identifiers As Value Objects |
+| [006-track-branch-lifecycle-explicitly.md](./006-track-branch-lifecycle-explicitly.md) | Track Branch Lifecycle Explicitly |
+| [007-use-result-types-for-recoverable-domain-operations.md](./007-use-result-types-for-recoverable-domain-operations.md) | Use Result Types For Recoverable Domain Operations |
+| [008-keep-unstable-query-apis-internal.md](./008-keep-unstable-query-apis-internal.md) | Keep Unstable Query Apis Internal |
+| [009-build-timelines-through-a-dedicated-builder.md](./009-build-timelines-through-a-dedicated-builder.md) | Build Timelines Through A Dedicated Builder |
+| [010-model-repository-activity-as-trace-events.md](./010-model-repository-activity-as-trace-events.md) | Model Repository Activity As Trace Events |
+| [011-optimize-timeline-builder-hot-paths.md](./011-optimize-timeline-builder-hot-paths.md) | Optimize Timeline Builder Hot Paths |
+| [065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md](./065-use-a-reusable-aggregation-engine-for-streaming-semantic-processing.md) | Use A Reusable Aggregation Engine For Streaming Semantic Processing |

--- a/Docs/Adr/diagnostics/013-keep-error-logs-detailed-for-failures.md
+++ b/Docs/Adr/diagnostics/013-keep-error-logs-detailed-for-failures.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](026-use-concise-warning-logs-for-expected-degradation.md)
+
+## [013] Keep Error Logs Detailed For Failures
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+These decisions distinguish hard failures from situations where the system continues with reduced data or functionality. This matters especially in provider aware export, where incomplete data does not always mean the whole operation failed.
+
+**Problem:**
+
+Real export and runtime failures require full diagnostic context.
+Logging in this system is not only for debugging failures, but also for communicating to the operator the difference between a hard error and controlled degradation.
+
+**Decision:**
+
+Logging keeps detailed information for `Error` and `Critical` cases.
+This decision separates logging policy for expected situations from logging policy for actual failure paths so the CLI stays readable without losing diagnostic information.
+
+**Rejected:**
+
+- The same short logs for every level.
+- Hiding exceptions from the operator or developer.
+- One logging policy in which warnings, degraded mode, and failures are not distinguished from each other.
+- Leaving success or export failure semantics to implicit interpretation instead of explicit logging rules.
+
+**Consequences:**
+
+Debugging serious failures remains possible, but failure must be distinguished from degraded mode.
+In practice, it is necessary to keep a clear threshold between warnings and errors, because that determines whether an export is treated as failed or simply incomplete.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](026-use-concise-warning-logs-for-expected-degradation.md)

--- a/Docs/Adr/diagnostics/026-use-concise-warning-logs-for-expected-degradation.md
+++ b/Docs/Adr/diagnostics/026-use-concise-warning-logs-for-expected-degradation.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](013-keep-error-logs-detailed-for-failures.md)
+
+## [026] Use Concise Warning Logs For Expected Degradation
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+These decisions distinguish hard failures from situations where the system continues with reduced data or functionality. This matters especially in provider aware export, where incomplete data does not always mean the whole operation failed.
+
+**Problem:**
+
+Not every provider API problem is an application failure.
+Logging in this system is not only for debugging failures, but also for communicating to the operator the difference between a hard error and controlled degradation.
+
+**Decision:**
+
+For expected degradation, warning logs stay concise, while full exception detail is reserved for serious errors.
+This decision separates logging policy for expected situations from logging policy for actual failure paths so the CLI stays readable without losing diagnostic information.
+
+**Rejected:**
+
+- Printing a full stack trace for every warning.
+- Silently skipping degraded behavior.
+- One logging policy in which warnings, degraded mode, and failures are not distinguished from each other.
+- Leaving success or export failure semantics to implicit interpretation instead of explicit logging rules.
+
+**Consequences:**
+
+CLI output stays clearer, but diagnostics must still indicate what was skipped or degraded.
+In practice, it is necessary to keep a clear threshold between warnings and errors, because that determines whether an export is treated as failed or simply incomplete.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](013-keep-error-logs-detailed-for-failures.md)

--- a/Docs/Adr/diagnostics/README.md
+++ b/Docs/Adr/diagnostics/README.md
@@ -1,0 +1,24 @@
+[ADR Home](../README.md)
+
+# diagnostics
+
+This category describes observability rules such as logging semantics and controlled degradation.
+
+## Scope
+
+Look here for warning/error behavior, diagnostic intent, and the difference between hard failure and expected degraded execution.
+
+## Responsibility Boundaries
+
+Diagnostics describes runtime signaling and observability policy. It should not redefine domain or export flow semantics.
+
+## How To Start Reading
+
+Start here when changing logs, degradation policy, or runtime observability behavior.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [013-keep-error-logs-detailed-for-failures.md](./013-keep-error-logs-detailed-for-failures.md) | Keep Error Logs Detailed For Failures |
+| [026-use-concise-warning-logs-for-expected-degradation.md](./026-use-concise-warning-logs-for-expected-degradation.md) | Use Concise Warning Logs For Expected Degradation |

--- a/Docs/Adr/export/012-keep-merge-detection-configurable.md
+++ b/Docs/Adr/export/012-keep-merge-detection-configurable.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](014-centralize-export-orchestration-in-a-single-repository-exporter.md)
+
+## [012] Keep Merge Detection Configurable
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Merge detection enriches the timeline with extra structure, but not every repository or export run needs that cost. Some histories are large enough that merge analysis becomes expensive, and some workflows only need the base commit stream.
+
+**Problem:**
+
+If merge detection is always on, export cost and failure surface increase even for runs that do not benefit from it. If it is always off, the exporter cannot produce richer merge aware side data when the operator actually wants it.
+
+**Decision:**
+
+Export exposes configurable merge detection. The caller can enable, disable, or choose merge related behavior explicitly instead of inheriting one global default for every repository.
+
+**Rejected:**
+
+- Always enabling merge detection.
+- Removing merge enrichment from export entirely.
+- Hiding merge behavior behind implicit repository size heuristics only.
+- Deferring all merge policy to downstream consumers after export finishes.
+
+**Consequences:**
+
+The operator can trade export speed against richer merge aware output deliberately. The tradeoff is that CLI, export options, and tests have to preserve one more piece of explicit export policy.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](014-centralize-export-orchestration-in-a-single-repository-exporter.md)

--- a/Docs/Adr/export/014-centralize-export-orchestration-in-a-single-repository-exporter.md
+++ b/Docs/Adr/export/014-centralize-export-orchestration-in-a-single-repository-exporter.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](012-keep-merge-detection-configurable.md) | [Next](015-record-export-stage-completion-explicitly.md)
+
+## [014] Centralize Export Orchestration In A Single Repository Exporter
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`RepositoryExporter` is not just another timeline persistence adapter. It is the central export orchestrator that ties together repository preparation, history reading, timeline building, enrichment, normalization, persistence, checkpoints, and the streaming variant.
+
+**Problem:**
+
+Export consists of multiple stages with different failure modes and different execution variants. When checkout, build, enrich, save, and resume are coordinated by several peer services or by the CLI, it becomes harder to maintain one model of progress, checkpoints, and the final semantics of success or degradation.
+
+**Decision:**
+
+Export orchestration remains concentrated in a single `RepositoryExporter`, which uses specialized dependencies but maintains the main workflow path. It decides the transitions between stages, the streaming variant, resume from checkpoints, and final timeline normalization.
+
+**Rejected:**
+
+- Coordinating export stages directly from the CLI layer.
+- Separate, inconsistent orchestrators for export, export+save, and resume.
+- Scattering checkpoint and enrichment responsibilities across helper services.
+- Treating export as one simple `read -> save` call without an explicit staged workflow.
+
+**Consequences:**
+
+Export has a single main control point, which simplifies progress tracking, degradation handling, and resume. The drawback is that `RepositoryExporter` becomes an important coordination class and requires discipline to avoid growing into an implementation monolith.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](012-keep-merge-detection-configurable.md) | [Next](015-record-export-stage-completion-explicitly.md)

--- a/Docs/Adr/export/015-record-export-stage-completion-explicitly.md
+++ b/Docs/Adr/export/015-record-export-stage-completion-explicitly.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](014-centralize-export-orchestration-in-a-single-repository-exporter.md) | [Next](016-stream-repository-export-to-reduce-memory-pressure.md)
+
+## [015] Record Export Stage Completion Explicitly
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Resumable export only works when the exporter can tell which stages completed, which were skipped intentionally, and which never finished. File presence alone is not enough once export produces multiple artifacts and optional enrichment paths.
+
+**Problem:**
+
+Resume logic must know which stages are complete, including optional enrichment stages that were skipped. Without explicit stage records, interrupted runs become ambiguous and the exporter cannot tell whether to replay work, trust existing outputs, or clear partial state.
+
+**Decision:**
+
+Checkpoints persist each export stage and its status explicitly. Export records stage outcomes as part of its own state model instead of inferring them only from files on disk.
+
+**Rejected:**
+
+- Inferring state only from the presence of files.
+- Re running every enrichment stage.
+- Treating export as one opaque transaction with no stage visibility.
+- Encoding stage progress only in logs or transient process memory.
+
+**Consequences:**
+
+Resume behavior becomes predictable and exporter state is easier to inspect and test. The tradeoff is that the stage model becomes a compatibility surface that future exporter changes must preserve or migrate deliberately.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](014-centralize-export-orchestration-in-a-single-repository-exporter.md) | [Next](016-stream-repository-export-to-reduce-memory-pressure.md)

--- a/Docs/Adr/export/016-stream-repository-export-to-reduce-memory-pressure.md
+++ b/Docs/Adr/export/016-stream-repository-export-to-reduce-memory-pressure.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](015-record-export-stage-completion-explicitly.md) | [Next](091-keep-libgit2sharp-as-a-backend-option.md)
+
+## [016] Stream Repository Export To Reduce Memory Pressure
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Repository export can process histories that are large enough to make full in memory timeline construction expensive. The exporter already stages work across reading, building, and persistence, so it has a natural place to adopt a more streaming oriented path.
+
+**Problem:**
+
+Large repositories become costly if the whole timeline is materialized before persistence begins. That increases managed memory pressure and delays failure visibility until late in the export.
+
+**Decision:**
+
+The exporter can stream repository events directly into `.gittrace`-oriented persistence paths instead of requiring one fully materialized in memory timeline first. Streaming is treated as an export mode decision inside the main pipeline rather than as a separate one off code path.
+
+**Rejected:**
+
+- Fully materializing every export before writing.
+- Optimizing only the serializers while leaving the exporter fully batch oriented.
+- Treating streaming as a CLI only shortcut outside the main exporter.
+- Splitting export into unrelated “streaming” and “regular” orchestrators.
+
+**Consequences:**
+
+Memory usage drops and long running exports can fail or checkpoint earlier in the pipeline. The tradeoff is that progressive persistence and in flight failure handling become part of exporter correctness, not just a persistence concern.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](015-record-export-stage-completion-explicitly.md) | [Next](091-keep-libgit2sharp-as-a-backend-option.md)

--- a/Docs/Adr/export/091-keep-libgit2sharp-as-a-backend-option.md
+++ b/Docs/Adr/export/091-keep-libgit2sharp-as-a-backend-option.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](016-stream-repository-export-to-reduce-memory-pressure.md) | [Next](092-support-a-git-cli-history-backend.md)
+
+## [091] Keep LibGit2Sharp As A Backend Option
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The exporter now has more than one way to read repository history, but existing LibGit2Sharp based behavior is still known, tested, and useful. Replacing it outright would turn a backend expansion decision into a risky migration of the primary export path.
+
+**Problem:**
+
+Adding a new backend should not force abandonment of a working library based integration. The export pipeline needs a stable backend abstraction that can compare implementations and fall back when one path is less suitable for a repository or environment.
+
+**Decision:**
+
+LibGit2Sharp remains one supported history reading backend behind the common reader contract. Backend selection becomes an exporter concern instead of a hardcoded choice in repository reading code.
+
+**Rejected:**
+
+- Removing LibGit2Sharp immediately when a second backend appears.
+- Keeping no backend abstraction at all.
+- Treating backend choice as a compile time fork instead of a runtime export decision.
+- Encoding backend choice only in benchmark or test code rather than in the exporter model.
+
+**Consequences:**
+
+The exporter can compare and retain known good behavior while broader backend support evolves. The tradeoff is that backend contracts, fallback rules, and behavioral parity now require ongoing validation.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](016-stream-repository-export-to-reduce-memory-pressure.md) | [Next](092-support-a-git-cli-history-backend.md)

--- a/Docs/Adr/export/092-support-a-git-cli-history-backend.md
+++ b/Docs/Adr/export/092-support-a-git-cli-history-backend.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](091-keep-libgit2sharp-as-a-backend-option.md) | [Next](097-use-atomic-file-transactions-for-multi-file-exports.md)
+
+## [092] Support A Git CLI History Backend
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Some repositories and environments benefit from reading history through the Git CLI rather than a linked library backend. A CLI based path also gives the exporter another option for large repositories and platform specific scenarios.
+
+**Problem:**
+
+LibGit2Sharp should not be the only path for reading repository history. If one implementation becomes the sole backend, exporter scalability and platform behavior are constrained by that one integration model.
+
+**Decision:**
+
+A backend based on Git CLI and a parser for its output is added behind the common history reader contract. The exporter can select that backend when it is a better fit while keeping the rest of the export pipeline unchanged.
+
+**Rejected:**
+
+- One history backend for every repository and environment.
+- Shelling out to Git with no tested parser contract.
+- Treating Git CLI support as a benchmark only experiment outside production export.
+- Building a backend path that bypasses the main exporter abstractions.
+
+**Consequences:**
+
+Export gains another scalable history reading option without splitting the rest of the pipeline. The tradeoff is that process execution, parser stability, and platform behavior become part of backend maintenance.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](091-keep-libgit2sharp-as-a-backend-option.md) | [Next](097-use-atomic-file-transactions-for-multi-file-exports.md)

--- a/Docs/Adr/export/097-use-atomic-file-transactions-for-multi-file-exports.md
+++ b/Docs/Adr/export/097-use-atomic-file-transactions-for-multi-file-exports.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](092-support-a-git-cli-history-backend.md) | [Next](098-use-sidecar-files-for-optional-timeline-data.md)
+
+## [097] Use Atomic File Transactions For Multi File Exports
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Export can now write a main artifact plus sidecars and checkpoint state. Once output spans multiple files, interruption during persistence can leave the repository with a partially updated artifact set.
+
+**Problem:**
+
+A `.gittrace` export together with sidecars can leave inconsistent state when the process is interrupted. If writes happen directly to destination files, resume and load behavior have to reason about partially replaced artifacts.
+
+**Decision:**
+
+Multi file persistence uses an atomic transactional approach to files. Export prepares and commits related output as one persistence unit instead of exposing each artifact incrementally in its final location.
+
+**Rejected:**
+
+- Writing directly into destination files.
+- Cleaning up only manually after a failure.
+- Treating partial file sets as acceptable normal output.
+- Delegating consistency guarantees entirely to callers or filesystem luck.
+
+**Consequences:**
+
+The risk of corrupted export state drops and resume logic sees cleaner persistence boundaries. The tradeoff is more complex I/O behavior and a stronger reliance on transaction style file management rules.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](092-support-a-git-cli-history-backend.md) | [Next](098-use-sidecar-files-for-optional-timeline-data.md)

--- a/Docs/Adr/export/098-use-sidecar-files-for-optional-timeline-data.md
+++ b/Docs/Adr/export/098-use-sidecar-files-for-optional-timeline-data.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](097-use-atomic-file-transactions-for-multi-file-exports.md) | [Next](099-write-sidecars-through-dedicated-handlers.md)
+
+## [098] Use Sidecar Files For Optional Timeline Data
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Pull request and merge related information can evolve independently from the main timeline payload. Forcing every optional enrichment into the core `.gittrace` artifact would make the base format carry data that not every repository or export run can provide.
+
+**Problem:**
+
+Merge and pull request enrichment can grow independently from the main timeline. The exporter needs a way to persist optional data without making the base timeline format unstable or forcing optional host metadata to behave like mandatory core state.
+
+**Decision:**
+
+Optional export data is persisted in the `.gittrace.parts` directory as sidecars related to the main artifact. The base timeline remains loadable on its own, while optional parts can be discovered and rehydrated when available.
+
+**Rejected:**
+
+- Packing all data into the main `.gittrace` file.
+- Separate files without a defined relationship to the timeline.
+- Treating sidecar output as ad hoc debug artifacts rather than part of the export contract.
+- Keeping optional host metadata only in memory after export.
+
+**Consequences:**
+
+The export format stays extensible without bloating the core artifact with optional host specific structures. The tradeoff is that readers, exporters, and diagnostics must all understand the relationship between the main artifact and its parts directory.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](097-use-atomic-file-transactions-for-multi-file-exports.md) | [Next](099-write-sidecars-through-dedicated-handlers.md)

--- a/Docs/Adr/export/099-write-sidecars-through-dedicated-handlers.md
+++ b/Docs/Adr/export/099-write-sidecars-through-dedicated-handlers.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](098-use-sidecar-files-for-optional-timeline-data.md) | [Next](100-use-checkpoints-for-resumable-export.md)
+
+## [099] Write Sidecars Through Dedicated Handlers
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Sidecars do not all share the same structure, lifecycle, or debugging needs. Pull request patches, merge artifacts, and related optional outputs have different persistence rules even though they participate in the same export.
+
+**Problem:**
+
+Each sidecar type has its own shape and write policy. If sidecar persistence is folded into the main timeline repository model, optional export concerns start to distort the core artifact path and sidecar evolution becomes hard to isolate.
+
+**Decision:**
+
+Sidecars are written through dedicated handlers. Each handler owns serialization and persistence rules for one sidecar type while the exporter orchestrates when those handlers run.
+
+**Rejected:**
+
+- One universal sidecar blob.
+- Keeping sidecar logic inside the main repository timeline model.
+- Treating sidecar writing as a generic file dump with no type specific contract.
+- Spreading sidecar persistence logic across exporter stages and helper services.
+
+**Consequences:**
+
+The code becomes more modular and sidecar types can evolve independently. The tradeoff is that each new sidecar introduces another contract, another handler, and more targeted test coverage requirements.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](098-use-sidecar-files-for-optional-timeline-data.md) | [Next](100-use-checkpoints-for-resumable-export.md)

--- a/Docs/Adr/export/100-use-checkpoints-for-resumable-export.md
+++ b/Docs/Adr/export/100-use-checkpoints-for-resumable-export.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](099-write-sidecars-through-dedicated-handlers.md)
+
+## [100] Use Checkpoints For Resumable Export
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Large exports can take long enough that interruption is a normal operating condition, not an edge case. Once export spans multiple stages and multiple artifacts, restart from zero becomes both slow and operationally wasteful.
+
+**Problem:**
+
+Long exports should not restart from zero after interruption. Without checkpoints, the exporter has to repeat repository reading, enrichment, and persistence work even when earlier stages completed successfully.
+
+**Decision:**
+
+Export maintains stage checkpoints and can resume work from those saved points. Checkpoints are part of exporter state rather than a side effect inferred from whatever files happen to exist.
+
+**Rejected:**
+
+- All or nothing export.
+- Treating partial files as an implicit checkpoint.
+- Rebuilding exporter state only from logs and artifact timestamps.
+- Moving resume support into an external wrapper instead of the exporter itself.
+
+**Consequences:**
+
+Resume becomes a first class export behavior and interruption cost drops for long running runs. The tradeoff is that checkpoint state becomes another durable contract that must stay compatible with exporter evolution and artifact layout changes.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](099-write-sidecars-through-dedicated-handlers.md)

--- a/Docs/Adr/export/README.md
+++ b/Docs/Adr/export/README.md
@@ -1,0 +1,32 @@
+[ADR Home](../README.md)
+
+# export
+
+This category describes export as a pipeline that reads repository history, enriches it, and persists artifacts.
+
+## Scope
+
+Look here for Git backends, sidecars, checkpoints, atomic persistence, resume, and repository to artifact flow.
+
+## Responsibility Boundaries
+
+Export is not just serialization. It is a pipeline that coordinates history reading, enrichment, artifact partitioning, and partial success behavior.
+
+## How To Start Reading
+
+Start here when changing repository reading, checkpointing, enrichment flow, or sidecars.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [012-keep-merge-detection-configurable.md](./012-keep-merge-detection-configurable.md) | Keep Merge Detection Configurable |
+| [014-centralize-export-orchestration-in-a-single-repository-exporter.md](./014-centralize-export-orchestration-in-a-single-repository-exporter.md) | Centralize Export Orchestration In A Single Repository Exporter |
+| [015-record-export-stage-completion-explicitly.md](./015-record-export-stage-completion-explicitly.md) | Record Export Stage Completion Explicitly |
+| [016-stream-repository-export-to-reduce-memory-pressure.md](./016-stream-repository-export-to-reduce-memory-pressure.md) | Stream Repository Export To Reduce Memory Pressure |
+| [091-keep-libgit2sharp-as-a-backend-option.md](./091-keep-libgit2sharp-as-a-backend-option.md) | Keep LibGit2Sharp As A Backend Option |
+| [092-support-a-git-cli-history-backend.md](./092-support-a-git-cli-history-backend.md) | Support A Git CLI History Backend |
+| [097-use-atomic-file-transactions-for-multi-file-exports.md](./097-use-atomic-file-transactions-for-multi-file-exports.md) | Use Atomic File Transactions For Multi File Exports |
+| [098-use-sidecar-files-for-optional-timeline-data.md](./098-use-sidecar-files-for-optional-timeline-data.md) | Use Sidecar Files For Optional Timeline Data |
+| [099-write-sidecars-through-dedicated-handlers.md](./099-write-sidecars-through-dedicated-handlers.md) | Write Sidecars Through Dedicated Handlers |
+| [100-use-checkpoints-for-resumable-export.md](./100-use-checkpoints-for-resumable-export.md) | Use Checkpoints For Resumable Export |

--- a/Docs/Adr/foundation/001-establish-changetrace-as-a-local-first-cli.md
+++ b/Docs/Adr/foundation/001-establish-changetrace-as-a-local-first-cli.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](002-use-c-and-net-as-the-application-platform.md)
+
+## [001] Establish Changetrace As A Local First CLI
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These are decisions at the highest level of abstraction. They define not so much an implementation detail as the frame within which the remaining modules can exist and remain coherent. A change in this area usually forces coordinated changes in many parts of the repository.
+
+**Problem:**
+
+ChangeTrace needs a clear local entry point without depending on a fixed server side service.
+This decision establishes the baseline assumptions of the system, and the rest of the repository is built around them.
+
+**Decision:**
+
+The primary system interface is a local CLI application, and execution state, exports, and playback remain on the local machine.
+This layer does not resolve domain details yet, but it defines the environment and constraints within which the later modules evolve.
+
+**Rejected:**
+
+- A web application as the first interface.
+- Requiring a remote ChangeTrace service in order to use the system.
+- Spreading these assumptions across unrelated documents and modules.
+- Deferring the platform decision until dependencies force it implicitly.
+
+**Consequences:**
+
+The system remains simple to run and local by nature, but storing data on the executing machine becomes an important contract.
+Changes in this area usually have system wide impact rather than affecting only one functional slice.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](002-use-c-and-net-as-the-application-platform.md)

--- a/Docs/Adr/foundation/002-use-c-and-net-as-the-application-platform.md
+++ b/Docs/Adr/foundation/002-use-c-and-net-as-the-application-platform.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](001-establish-changetrace-as-a-local-first-cli.md)
+
+## [002] Use C And Net As The Application Platform
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These are decisions at the highest level of abstraction. They define not so much an implementation detail as the frame within which the remaining modules can exist and remain coherent. A change in this area usually forces coordinated changes in many parts of the repository.
+
+**Problem:**
+
+The project requires one technology stack for the CLI, serialization, Git integration, tests, and later graphics work.
+This decision establishes the baseline assumptions of the system, and the rest of the repository is built around them.
+
+**Decision:**
+
+The application is built as a C#/.NET project, with the .NET solution as the primary build and distribution mechanism.
+This layer does not resolve domain details yet, but it defines the environment and constraints within which the later modules evolve.
+
+**Rejected:**
+
+- Scripts as the main application form.
+- A multilingual core at project start.
+- Spreading these assumptions across unrelated documents and modules.
+- Deferring the platform decision until dependencies force it implicitly.
+
+**Consequences:**
+
+One runtime simplifies refactoring and testing, but library choice and distribution stay tied to the .NET ecosystem.
+Changes in this area usually have system wide impact rather than affecting only one functional slice.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](001-establish-changetrace-as-a-local-first-cli.md)

--- a/Docs/Adr/foundation/README.md
+++ b/Docs/Adr/foundation/README.md
@@ -1,0 +1,24 @@
+[ADR Home](../README.md)
+
+# foundation
+
+This category captures the highest level system and platform assumptions that shape the rest of the codebase.
+
+## Scope
+
+Look here for decisions about baseline runtime, platform direction, and the top level execution model.
+
+## Responsibility Boundaries
+
+Foundation does not describe local implementation details. It defines the environment and constraints within which other layers operate.
+
+## How To Start Reading
+
+Start here when a change questions top level system assumptions or platform choices.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [001-establish-changetrace-as-a-local-first-cli.md](./001-establish-changetrace-as-a-local-first-cli.md) | Establish Changetrace As A Local First CLI |
+| [002-use-c-and-net-as-the-application-platform.md](./002-use-c-and-net-as-the-application-platform.md) | Use C And Net As The Application Platform |

--- a/Docs/Adr/graphics/068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md
+++ b/Docs/Adr/graphics/068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](069-use-gpu-driven-rendering-for-dense-visuals.md)
+
+## [068] Share Compute Pipeline Bases For GPU Culling And Texture Generation
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The `graphics/` code maintains two shared compute pipeline patterns: `IndirectComputePipeline<TGpuItem>` for compaction and indirect draw, and `TextureComputePipeline<TData>` for texture generation or processing. Concrete pipelines inherit from those bases instead of reimplementing synchronization and binding from scratch.
+
+**Problem:**
+
+GPU pipelines for circles, edges, text, particles, and heatmaps share the same set of low level operations: upload, storage buffer binding, dispatch, memory barriers, and indirect draw or image texture state reset. Duplicating those sequences in every pipeline increases the risk of inconsistent barriers and hard to detect GPU synchronization errors.
+
+**Decision:**
+
+Shared compute mechanics are kept in base pipeline classes, while concrete pipelines add only data contracts and specific shaders. This applies both to pipelines that compact data for indirect draw and to pipelines that produce derived textures.
+
+**Rejected:**
+
+- Reimplementing binding, dispatch, and memory barriers in every pipeline separately.
+- One universal pipeline for every kind of GPU workload.
+- Hiding compute contracts behind one high level generic renderer.
+- Moving GPU synchronization responsibilities into pass layers or the window runtime.
+
+**Consequences:**
+
+GPU synchronization and the compute work pattern remain consistent across pipelines, and new workloads are easier to attach to the existing architecture. In return, the base classes become an important technical contract and must not drift into an overly generic abstraction detached from real runtime needs.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](069-use-gpu-driven-rendering-for-dense-visuals.md)

--- a/Docs/Adr/graphics/069-use-gpu-driven-rendering-for-dense-visuals.md
+++ b/Docs/Adr/graphics/069-use-gpu-driven-rendering-for-dense-visuals.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md) | [Next](076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md)
+
+## [069] Use GPU Driven Rendering For Dense Visuals
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Repository scenes can contain large numbers of edges, particles, labels, and icons. A backend that depends mainly on CPU side per item draw orchestration will hit scaling limits long before the rest of the rendering model does.
+
+**Problem:**
+
+Dense scenes become expensive when the CPU is responsible for preparing and issuing every visual item independently. The graphics runtime needs a model where culling, compaction, and indirect draw preparation can happen closer to the GPU.
+
+**Decision:**
+
+The runtime uses GPU driven rendering for dense visuals. Compute and buffer pipelines prepare draw ready state, and the backend relies on GPU side work to reduce CPU coordination pressure for large scenes.
+
+**Rejected:**
+
+- Drawing every element through a separate high level draw call.
+- Keeping scene density handling as a CPU only optimization problem.
+- Treating particles, edges, and dense overlays as special case effects outside the main backend model.
+- Hiding GPU driven behavior behind one opaque renderer with no explicit data contracts.
+
+**Consequences:**
+
+Dense repository views scale better and the backend can keep more of the heavy draw preparation work on the GPU. The tradeoff is that shaders, buffers, and GPU synchronization become first class architectural concerns rather than incidental backend details.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md) | [Next](076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md)

--- a/Docs/Adr/graphics/076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md
+++ b/Docs/Adr/graphics/076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](069-use-gpu-driven-rendering-for-dense-visuals.md) | [Next](077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md)
+
+## [076] Build Specialized Buffer Wrappers On Top Of A Generic GPU Buffer
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The `ChangeTrace.Graphics.Gpu.Buffers` layer has a shared core in the form of `GpuBuffer<T>`, but it does not expose it as the only public runtime abstraction. On top of it sit specialized wrappers such as `ShaderStorageBuffer<T>`, `VertexBuffer<T>`, `IndexBuffer<TCommand>`, and `IndirectDrawBuffer<TCommand>`, each with an assigned OpenGL target and operations specific to its use case.
+
+**Problem:**
+
+GPU buffers share allocation, upload, and disposal mechanics, but they differ in target semantics, binding patterns, and where they are used in the pipeline. Using only one generic `GpuBuffer<T>` wrapper throughout the runtime would force renderers and pipelines to know on every call which target they are working with and which operations are valid for it.
+
+**Decision:**
+
+The low level `GpuBuffer<T>` remains the shared core for lifecycle and upload, while the runtime mostly uses specialized wrappers for different OpenGL buffer classes. Buffer type semantics are encoded in the `Gpu.Buffers` layer instead of being scattered across renderers and compute pipelines.
+
+**Rejected:**
+
+- Using one universal `GpuBuffer<T>` directly from every pipeline and renderer.
+- Separate, duplicated allocation and upload implementations for every buffer type.
+- Encoding the OpenGL target as a loose parameter passed everywhere from the outside.
+- Combining GPU data contracts with responsibility for raw buffer operations in the same classes.
+
+**Consequences:**
+
+The buffer layer becomes more readable and enforces more correct usage semantics on the renderer and pipeline side. The cost is a larger number of small wrappers that must stay aligned with the `GpuBuffer<T>` core and the real OpenGL usage model.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](069-use-gpu-driven-rendering-for-dense-visuals.md) | [Next](077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md)

--- a/Docs/Adr/graphics/077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md
+++ b/Docs/Adr/graphics/077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md) | [Next](078-use-typed-gpu-buffer-contracts.md)
+
+## [077] Keep Buffer Lifecycle And Binding Logic Out Of Renderers And Pipelines
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Classes in `ChangeTrace.Graphics.Gpu.Buffers` encapsulate operations such as `GenBuffer`, `BindBuffer`, `BufferData`, `BufferSubData`, `BindBase`, and `DeleteBuffer`. GPU pipelines and scene renderers use those wrappers, but do not manage the full lifecycle of raw buffer handles directly.
+
+**Problem:**
+
+A renderer or pipeline that both computes data, manages shaders, and manually handles raw buffer lifecycle quickly accumulates too many responsibilities. That increases the risk of OpenGL state errors, inconsistent binding, and hard to find resource leaks.
+
+**Decision:**
+
+Buffer lifecycle and basic binding operations remain encapsulated in a dedicated `Gpu.Buffers` layer. Renderers and pipelines work with wrappers that carry explicit semantics instead of directly managing handles and raw `GL.*Buffer*` calls.
+
+**Rejected:**
+
+- Creating and deleting buffer handles manually in each renderer.
+- Duplicating `Bind` / `BufferData` / `Delete` sequences in compute pipelines and passes.
+- Treating buffer lifecycle as a detail of one renderer instead of shared infrastructure.
+- Hiding buffer semantics behind a generic helper without usage specific types.
+
+**Consequences:**
+
+Execution becomes less vulnerable to inconsistent OpenGL state, and GPU resource management stays concentrated in one place. The downside is that buffer wrappers become a critical part of the runtime, so their failures have broader impact than a single renderer failure.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md) | [Next](078-use-typed-gpu-buffer-contracts.md)

--- a/Docs/Adr/graphics/078-use-typed-gpu-buffer-contracts.md
+++ b/Docs/Adr/graphics/078-use-typed-gpu-buffer-contracts.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md) | [Next](079-provide-runtime-fallbacks-for-text-and-icon-assets.md)
+
+## [078] Use Typed GPU Buffer Contracts
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+GPU pipelines only behave correctly when CPU side layout and shader side layout agree exactly. In a runtime with multiple buffer kinds, indirect draw commands, and compute passes, untyped buffer payloads make those contracts too easy to break silently.
+
+**Problem:**
+
+CPU and GPU must agree on data layout, binding meaning, and element semantics. If those rules exist only in shader code or only in comments, buffer misuse and layout drift become difficult to detect before runtime breakage.
+
+**Decision:**
+
+GPU data is described through explicit typed buffer contracts and matching wrappers. Buffer payload types encode layout assumptions on the CPU side, and the runtime binds them through buffer types that correspond to real usage patterns.
+
+**Rejected:**
+
+- Encoding data layout only in the shader.
+- Using untyped byte ranges everywhere in CPU side pipeline code.
+- Treating binding semantics as free form integers passed between subsystems.
+- Copying layout definitions independently into each renderer or compute pass.
+
+**Consequences:**
+
+GPU buffer usage becomes more explicit and easier to review against shader expectations. The tradeoff is that changing a GPU side layout now requires coordinated updates to typed contracts instead of a local shader edit.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md) | [Next](079-provide-runtime-fallbacks-for-text-and-icon-assets.md)

--- a/Docs/Adr/graphics/079-provide-runtime-fallbacks-for-text-and-icon-assets.md
+++ b/Docs/Adr/graphics/079-provide-runtime-fallbacks-for-text-and-icon-assets.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](078-use-typed-gpu-buffer-contracts.md) | [Next](080-render-labels-and-icons-through-atlas-assets.md)
+
+## [079] Provide Runtime Fallbacks For Text And Icon Assets
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The text and icon runtime does not assume that every asset is always present on disk. `FontAtlasLoader` can generate a built in glyph atlas, and `LanguageIconAtlasLoader` searches several locations and can degrade cleanly to a no icons state.
+
+**Problem:**
+
+The graphics backend should not be inseparably tied to the presence of one asset set in one specific directory. Missing a text atlas or icons must not automatically disable the entire runtime, especially in local, development, and debug scenarios.
+
+**Decision:**
+
+Graphics maintains runtime fallbacks for critical text assets and controlled degradation for optional assets. Text has a built in recovery path, while language icons are treated as an optional resource.
+
+**Rejected:**
+
+- Failing initialization hard when any bitmap asset is missing.
+- Assuming one fixed location for every atlas.
+- Generating fallbacks only in a higher rendering layer.
+- Mixing asset resolution logic into scene and HUD renderers.
+
+**Consequences:**
+
+The runtime becomes easier to start in different environments and modes, and one missing asset does not stop the whole visualization. The tradeoff is maintaining two behavior paths: a full path with assets and a degraded path with fallbacks or no icons.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](078-use-typed-gpu-buffer-contracts.md) | [Next](080-render-labels-and-icons-through-atlas-assets.md)

--- a/Docs/Adr/graphics/080-render-labels-and-icons-through-atlas-assets.md
+++ b/Docs/Adr/graphics/080-render-labels-and-icons-through-atlas-assets.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](079-provide-runtime-fallbacks-for-text-and-icon-assets.md) | [Next](081-keep-shader-sources-as-validated-assets.md)
+
+## [080] Render Labels And Icons Through Atlas Assets
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Labels and language icons are rendered frequently across HUD and scene overlays. Issuing separate texture resources or draw setup for each glyph and icon would add unnecessary overhead to a runtime that already handles dense visual layers.
+
+**Problem:**
+
+Text and icon rendering become expensive if every asset is resolved and bound independently at runtime. The runtime needs one predictable resource layout that supports repeated label drawing without turning UI overlays into a stream of tiny texture operations.
+
+**Decision:**
+
+The renderer uses glyph and language icon atlases. Text and icon lookups resolve into atlas coordinates, and the backend draws those assets through shared texture resources rather than per item bitmap loading.
+
+**Rejected:**
+
+- Loading icons one by one at runtime.
+- Having no language icons in the visualization.
+- Generating per label textures during normal frame execution.
+- Treating text and icon assets as unrelated runtime paths with separate draw models.
+
+**Consequences:**
+
+Label and icon rendering become cheaper and more predictable under repeated use. The tradeoff is that atlas generation, versioning, and fallback behavior become explicit asset management concerns inside the graphics runtime.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](079-provide-runtime-fallbacks-for-text-and-icon-assets.md) | [Next](081-keep-shader-sources-as-validated-assets.md)

--- a/Docs/Adr/graphics/081-keep-shader-sources-as-validated-assets.md
+++ b/Docs/Adr/graphics/081-keep-shader-sources-as-validated-assets.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](080-render-labels-and-icons-through-atlas-assets.md) | [Next](082-register-runtime-shaders-through-a-static-manifest.md)
+
+## [081] Keep Shader Sources As Validated Assets
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Shaders are source assets that define runtime behavior for passes, pipelines, and GPU side effects. They fail differently from regular code changes because compile time coverage is weaker and backend breakage often appears only when a graphics path is exercised.
+
+**Problem:**
+
+Leaving shader files as opaque text artifacts means errors show up late, often only after a window or pass path starts executing. The graphics runtime needs a way to treat shader completeness and validity as part of the asset contract rather than as incidental file presence.
+
+**Decision:**
+
+Shader sources are treated as validated assets. The repository keeps them in the asset workflow, and validation happens through build or CI paths before the runtime is the first place to discover obvious breakage.
+
+**Rejected:**
+
+- Treating shaders as uncontrolled text files.
+- Validating only when the window starts.
+- Treating shader compile failures as an unavoidable runtime only concern.
+- Embedding shader source strings directly in renderer code to avoid asset management.
+
+**Consequences:**
+
+The graphics path becomes more predictable and shader regressions can be caught earlier in development. The tradeoff is that the asset pipeline has to stay maintained as part of normal graphics engineering rather than as an optional convenience.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](080-render-labels-and-icons-through-atlas-assets.md) | [Next](082-register-runtime-shaders-through-a-static-manifest.md)

--- a/Docs/Adr/graphics/082-register-runtime-shaders-through-a-static-manifest.md
+++ b/Docs/Adr/graphics/082-register-runtime-shaders-through-a-static-manifest.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](081-keep-shader-sources-as-validated-assets.md) | [Next](083-render-derived-effects-into-dedicated-gpu-targets.md)
+
+## [082] Register Runtime Shaders Through A Static Manifest
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The shader layer maintains an explicit `ShaderManifest` that registers runtime shader names, their `ShaderKind`, and the corresponding asset paths. The runtime does not scan shader directories dynamically at startup and does not rely on ad hoc file references from individual renderers.
+
+**Problem:**
+
+The graphics backend needs a stable `name -> shader definition` map so that passes, pipelines, and runtime resources can request concrete programs without knowing the physical file locations. Without a central manifest, shader knowledge gets scattered across renderers, and renaming a shader or changing its kind becomes difficult to trace.
+
+**Decision:**
+
+Runtime shaders are registered through a static manifest of definitions, which forms a contract between assets, the shader loader, and the graphics layer. A shader name becomes a stable runtime identifier rather than just a file name known to a single renderer.
+
+**Rejected:**
+
+- Dynamically scanning shader directories on every startup.
+- Direct references to raw shader asset paths from renderers.
+- Separate local shader registries maintained by each pipeline.
+- Coupling shader kind and path knowledge directly to concrete pass code.
+
+**Consequences:**
+
+The shader runtime becomes more predictable and it is easier to control asset completeness and naming consistency across the graphics backend. The cost is having to maintain the manifest as a central contract and update it whenever a new runtime shader is added.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](081-keep-shader-sources-as-validated-assets.md) | [Next](083-render-derived-effects-into-dedicated-gpu-targets.md)

--- a/Docs/Adr/graphics/083-render-derived-effects-into-dedicated-gpu-targets.md
+++ b/Docs/Adr/graphics/083-render-derived-effects-into-dedicated-gpu-targets.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](082-register-runtime-shaders-through-a-static-manifest.md) | [Next](084-execute-graphics-runtime-through-an-ordered-frame-graph.md)
+
+## [083] Render Derived Effects Into Dedicated GPU Targets
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The graphics runtime maintains separate GPU targets for derived effects instead of treating them as direct drawing into the main backbuffer. The code uses explicit textures and framebuffers for stages such as trail accumulation, heatmaps, and bloom masks.
+
+**Problem:**
+
+Accumulation and post process effects need their own resource lifecycle, resolution, and synchronization model. When they are computed directly in the main draw path, resize handling, texture reuse, and composition of intermediate data stages become harder to manage.
+
+**Decision:**
+
+Derived effects are rendered or generated into dedicated GPU targets and only then consumed by subsequent passes. This applies both to framebuffers drawn by fullscreen passes and to textures written by compute shaders.
+
+**Rejected:**
+
+- Computing every effect directly in the main draw path without intermediate resources.
+- Keeping effect data on the CPU side between passes.
+- Mixing effect target lifecycle with the base geometry buffers.
+- Creating temporary targets ad hoc inside renderers instead of maintaining explicit resource components.
+
+**Consequences:**
+
+The effects pipeline becomes more modular and handles resize and implementation swaps better. The tradeoff is a larger number of GPU resources and stricter discipline around texture formats, framebuffers, and memory barriers.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](082-register-runtime-shaders-through-a-static-manifest.md) | [Next](084-execute-graphics-runtime-through-an-ordered-frame-graph.md)

--- a/Docs/Adr/graphics/084-execute-graphics-runtime-through-an-ordered-frame-graph.md
+++ b/Docs/Adr/graphics/084-execute-graphics-runtime-through-an-ordered-frame-graph.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](083-render-derived-effects-into-dedicated-gpu-targets.md) | [Next](085-keep-opentk-render-output-as-a-thin-runtime-adapter.md)
+
+## [084] Execute Graphics Runtime Through An Ordered Frame Graph
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`OpenTkRenderRuntime` does not invoke the scene renderer as one monolithic step. It builds a `RenderFrameGraph`, registers successive `RenderPass` instances in it, and executes them sequentially for each frame.
+
+**Problem:**
+
+The graphics runtime must maintain a stable layer order: background, heatmap, edges, nodes, particles, and HUD. When that order is scattered across many methods or hidden inside one renderer, pass dependencies, profiling, and pipeline rebuilds during resize or resource changes become harder to control.
+
+**Decision:**
+
+A render frame is executed through an explicit sequential frame graph built from `RenderPass`. The runtime composes the graph and passes a shared `RenderFrameContext`, while the logic of individual passes remains isolated.
+
+**Rejected:**
+
+- One renderer executing every stage in one method.
+- Encoding pass order directly inside scene renderer classes.
+- Building a dynamic dependency DAG without a real need in the current runtime.
+- Merging frame orchestration layers with single effect implementations.
+
+**Consequences:**
+
+Pass order and responsibility become explicit, and the runtime can be profiled and rebuilt without touching every renderer. The cost is a larger set of execution objects and the need to preserve the `RenderFrameContext` contract and stable pass ordering.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](083-render-derived-effects-into-dedicated-gpu-targets.md) | [Next](085-keep-opentk-render-output-as-a-thin-runtime-adapter.md)

--- a/Docs/Adr/graphics/085-keep-opentk-render-output-as-a-thin-runtime-adapter.md
+++ b/Docs/Adr/graphics/085-keep-opentk-render-output-as-a-thin-runtime-adapter.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](084-execute-graphics-runtime-through-an-ordered-frame-graph.md) | [Next](086-use-opentk-as-the-windowing-and-opengl-runtime.md)
+
+## [085] Keep OpenTK Render Output As A Thin Runtime Adapter
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`OpenTkRenderOutput` implements the `IRenderOutput` contract, but it does not take ownership of pass composition, pipelines, or GPU resources. That logic stays in `OpenTkRenderRuntime`, while the output acts as a lifecycle and `RenderState` adapter.
+
+**Problem:**
+
+The integration with `Rendering` needs a stable output contract, but it should not receive the full details of OpenGL, passes, and shaders. When adapter and runtime are merged into one object, the boundary between the system contract and graphics backend details erodes quickly.
+
+**Decision:**
+
+`IRenderOutput` remains a thin adapter over the OpenTK backend, while all execution details stay behind a separate runtime class. The adapter is responsible only for `Initialize`, `Submit`, `Resize`, and `Dispose`.
+
+**Rejected:**
+
+- Exposing `OpenTkRenderRuntime` directly as the implementation of a higher layer contract.
+- Moving pass and pipeline construction logic into the output adapter.
+- Coupling the `IRenderOutput` contract to APIs specific to OpenGL or OpenTK.
+- Spreading renderer lifecycle across the window, pipeline, and runtime without one boundary class.
+
+**Consequences:**
+
+The `rendering/` layer sees a simple output contract, while the OpenTK backend can evolve without changing the higher layer interface. The drawback is an extra delegation layer that must remain aligned with the runtime and its lifecycle.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](084-execute-graphics-runtime-through-an-ordered-frame-graph.md) | [Next](086-use-opentk-as-the-windowing-and-opengl-runtime.md)

--- a/Docs/Adr/graphics/086-use-opentk-as-the-windowing-and-opengl-runtime.md
+++ b/Docs/Adr/graphics/086-use-opentk-as-the-windowing-and-opengl-runtime.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](085-keep-opentk-render-output-as-a-thin-runtime-adapter.md) | [Next](087-keep-input-controllers-outside-rendering-state.md)
+
+## [086] Use OpenTK As The Windowing And OpenGL Runtime
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+The project needs a runtime that can host debug and player windows, manage OpenGL context lifetime, and integrate cleanly with .NET. That runtime sits below rendering policy and above platform specific window and input behavior.
+
+**Problem:**
+
+The graphics backend needs explicit control over context creation, resize handling, and frame execution, but building a custom platform layer would be expensive and tying the project to a full game engine would import unrelated lifecycle assumptions.
+
+**Decision:**
+
+OpenTK provides the windowing layer, input handling, and OpenGL context for the graphics runtime. Higher level rendering code stays separate, but window and GPU execution rely on OpenTK as the concrete host runtime.
+
+**Rejected:**
+
+- Building a custom platform wrapper for windowing and context management.
+- Depending on a game engine as the main runtime.
+- Treating the GPU and asset pipeline as an implementation detail without explicit data contracts.
+- Moving responsibility for input, window runtime behavior, and shader assets into rendering logic or a presentation layer.
+
+**Consequences:**
+
+The runtime stays close to .NET and gives explicit control over graphics lifecycle behavior. The tradeoff is that platform validation and OpenTK specific runtime concerns become part of the graphics maintenance surface.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](085-keep-opentk-render-output-as-a-thin-runtime-adapter.md) | [Next](087-keep-input-controllers-outside-rendering-state.md)

--- a/Docs/Adr/graphics/087-keep-input-controllers-outside-rendering-state.md
+++ b/Docs/Adr/graphics/087-keep-input-controllers-outside-rendering-state.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](086-use-opentk-as-the-windowing-and-opengl-runtime.md) | [Next](088-use-debug-windows-for-rendering-development.md)
+
+## [087] Keep Input Controllers Outside Rendering State
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Mouse and keyboard input influence camera motion, selection, and playback control, but they are not themselves part of the scene model. The graphics runtime needs to convert operator input into commands without turning transient device state into persistent rendering state.
+
+**Problem:**
+
+If input handling is embedded in the scene graph or scattered across render outputs, interaction rules become hard to test and easy to desynchronize from player and camera behavior. The runtime needs one place where input intent is interpreted before scene or playback state changes.
+
+**Decision:**
+
+Input is handled by dedicated controllers outside rendering state. Controllers read window events and translate them into camera, hover, or playback actions without making scene state structures own device event policy directly.
+
+**Rejected:**
+
+- Handling input inside the scene graph.
+- Spreading keyboard conditions across render outputs.
+- Binding camera and playback controls directly to raw window callbacks in many places.
+- Treating input state as part of the persistent render state model.
+
+**Consequences:**
+
+Interaction logic becomes easier to reason about and easier to align with player and camera contracts. The tradeoff is that controller behavior becomes its own integration layer between windows, rendering state, and playback.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](086-use-opentk-as-the-windowing-and-opengl-runtime.md) | [Next](088-use-debug-windows-for-rendering-development.md)

--- a/Docs/Adr/graphics/088-use-debug-windows-for-rendering-development.md
+++ b/Docs/Adr/graphics/088-use-debug-windows-for-rendering-development.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](087-keep-input-controllers-outside-rendering-state.md)
+
+## [088] Use Debug Windows For Rendering Development
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Rendering behavior is hard to diagnose through logs alone because many failures are spatial, temporal, or resource dependent. The graphics runtime benefits from dedicated windows that can expose scene state, debug overlays, and backend behavior interactively.
+
+**Problem:**
+
+A CLI command alone is not enough to inspect frame composition, hover behavior, layout drift, or pass level output. Without dedicated debug windows, graphics diagnosis gets pushed into ad hoc logging and production player workflows that are too indirect for rapid iteration.
+
+**Decision:**
+
+The project exposes debug and player windows for runtime inspection. Rendering development and diagnostics can exercise graphics behavior through dedicated runtime surfaces instead of relying only on the normal production facing path.
+
+**Rejected:**
+
+- Debugging only through logs.
+- Using the production window as the only way to test graphics.
+- Treating debug visualization as an external only tool outside the runtime.
+- Folding every inspection need into the main player surface with no separate diagnostics path.
+
+**Consequences:**
+
+Rendering development becomes faster and graphics issues become easier to localize interactively. The tradeoff is that debug windows add more runtime surfaces whose lifecycle and diagnostic behavior must stay isolated from the main workflow.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](087-keep-input-controllers-outside-rendering-state.md)

--- a/Docs/Adr/graphics/README.md
+++ b/Docs/Adr/graphics/README.md
@@ -1,0 +1,37 @@
+[ADR Home](../README.md)
+
+# graphics
+
+This category describes the executable graphics runtime: OpenTK, GPU, shaders, buffers, atlases, and input.
+
+## Scope
+
+Look here for render execution, shader assets, GPU contracts, windows, input controllers, and OpenGL runtime behavior.
+
+## Responsibility Boundaries
+
+Graphics does not model domain data or logical scene behavior. It executes decisions that were already made in `rendering/`.
+
+## How To Start Reading
+
+Start here when changing shaders, GPU buffers, runtime windows, or low level rendering execution.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md](./068-share-compute-pipeline-bases-for-gpu-culling-and-texture-generation.md) | Share Compute Pipeline Bases For GPU Culling And Texture Generation |
+| [069-use-gpu-driven-rendering-for-dense-visuals.md](./069-use-gpu-driven-rendering-for-dense-visuals.md) | Use GPU Driven Rendering For Dense Visuals |
+| [076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md](./076-build-specialized-buffer-wrappers-on-top-of-a-generic-gpu-buffer.md) | Build Specialized Buffer Wrappers On Top Of A Generic GPU Buffer |
+| [077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md](./077-keep-buffer-lifecycle-and-binding-logic-out-of-renderers-and-pipelines.md) | Keep Buffer Lifecycle And Binding Logic Out Of Renderers And Pipelines |
+| [078-use-typed-gpu-buffer-contracts.md](./078-use-typed-gpu-buffer-contracts.md) | Use Typed GPU Buffer Contracts |
+| [079-provide-runtime-fallbacks-for-text-and-icon-assets.md](./079-provide-runtime-fallbacks-for-text-and-icon-assets.md) | Provide Runtime Fallbacks For Text And Icon Assets |
+| [080-render-labels-and-icons-through-atlas-assets.md](./080-render-labels-and-icons-through-atlas-assets.md) | Render Labels And Icons Through Atlas Assets |
+| [081-keep-shader-sources-as-validated-assets.md](./081-keep-shader-sources-as-validated-assets.md) | Keep Shader Sources As Validated Assets |
+| [082-register-runtime-shaders-through-a-static-manifest.md](./082-register-runtime-shaders-through-a-static-manifest.md) | Register Runtime Shaders Through A Static Manifest |
+| [083-render-derived-effects-into-dedicated-gpu-targets.md](./083-render-derived-effects-into-dedicated-gpu-targets.md) | Render Derived Effects Into Dedicated GPU Targets |
+| [084-execute-graphics-runtime-through-an-ordered-frame-graph.md](./084-execute-graphics-runtime-through-an-ordered-frame-graph.md) | Execute Graphics Runtime Through An Ordered Frame Graph |
+| [085-keep-opentk-render-output-as-a-thin-runtime-adapter.md](./085-keep-opentk-render-output-as-a-thin-runtime-adapter.md) | Keep OpenTK Render Output As A Thin Runtime Adapter |
+| [086-use-opentk-as-the-windowing-and-opengl-runtime.md](./086-use-opentk-as-the-windowing-and-opengl-runtime.md) | Use OpenTK As The Windowing And OpenGL Runtime |
+| [087-keep-input-controllers-outside-rendering-state.md](./087-keep-input-controllers-outside-rendering-state.md) | Keep Input Controllers Outside Rendering State |
+| [088-use-debug-windows-for-rendering-development.md](./088-use-debug-windows-for-rendering-development.md) | Use Debug Windows For Rendering Development |

--- a/Docs/Adr/persistence/017-optimize-gittrace-serialization-hot-paths.md
+++ b/Docs/Adr/persistence/017-optimize-gittrace-serialization-hot-paths.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](018-persist-timelines-as-portable-gittrace-files.md)
+
+## [017] Optimize gittrace Serialization Hot Paths
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+`.gittrace` serialization is critical for export time and file size.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:**
+
+Formatters and DTOs are optimized for `.gittrace` persistence and reads.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:**
+
+- Changing the format without attempting optimization.
+- Leaving serialization performance unmeasured.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+The format remains stable, but the optimizations must be controlled by compatibility tests.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](018-persist-timelines-as-portable-gittrace-files.md)

--- a/Docs/Adr/persistence/018-persist-timelines-as-portable-gittrace-files.md
+++ b/Docs/Adr/persistence/018-persist-timelines-as-portable-gittrace-files.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](017-optimize-gittrace-serialization-hot-paths.md) | [Next](019-use-streaming-serializers-for-gittrace-writes.md)
+
+## [018] Persist Timelines As Portable gittrace Files
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+The operator must be able to export a repository and restore it later without rereading Git history.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:**
+
+The durable export artifact is the `.gittrace` file.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:**
+
+- Reconstructing from the repository on every run.
+- A format coupled to the graphics window or runtime.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+Export becomes portable, but the file format requires careful evolution.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](017-optimize-gittrace-serialization-hot-paths.md) | [Next](019-use-streaming-serializers-for-gittrace-writes.md)

--- a/Docs/Adr/persistence/019-use-streaming-serializers-for-gittrace-writes.md
+++ b/Docs/Adr/persistence/019-use-streaming-serializers-for-gittrace-writes.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](018-persist-timelines-as-portable-gittrace-files.md) | [Next](032-separate-persisted-dtos-from-domain-objects.md)
+
+## [019] Use Streaming Serializers For gittrace Writes
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+Streaming export requires serializers that do not assume the full object graph is in memory.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:**
+
+The serializer layer provides explicit streaming contracts for `.gittrace` writes.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:**
+
+- Serializers that only support complete in memory objects.
+- Hard coding streaming persistence directly in the exporter.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+The serializer becomes more flexible, but it has more execution paths to test.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](018-persist-timelines-as-portable-gittrace-files.md) | [Next](032-separate-persisted-dtos-from-domain-objects.md)

--- a/Docs/Adr/persistence/032-separate-persisted-dtos-from-domain-objects.md
+++ b/Docs/Adr/persistence/032-separate-persisted-dtos-from-domain-objects.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](019-use-streaming-serializers-for-gittrace-writes.md) | [Next](037-keep-file-access-behind-file-manager-abstractions.md)
+
+## [032] Separate Persisted DTOs From Domain Objects
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+Domain objects can evolve differently from the format persisted on disk.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:**
+
+The `.gittrace` format uses DTOs that are separated from domain models.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:**
+
+- Serializing domain models directly.
+- Using one type for domain, transport, and persistence.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+The domain can be refactored, but DTO mappings require maintenance and tests.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](019-use-streaming-serializers-for-gittrace-writes.md) | [Next](037-keep-file-access-behind-file-manager-abstractions.md)

--- a/Docs/Adr/persistence/037-keep-file-access-behind-file-manager-abstractions.md
+++ b/Docs/Adr/persistence/037-keep-file-access-behind-file-manager-abstractions.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](032-separate-persisted-dtos-from-domain-objects.md) | [Next](038-use-messagepack-for-timeline-persistence.md)
+
+## [037] Keep File Access Behind File Manager Abstractions
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+Export, workspace storage, and token stores need I/O, but they should not duplicate file handling logic.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:** 
+
+File operations are isolated behind file manager interfaces and services.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:**
+
+- Direct `File.WriteAllBytes` calls inside handlers.
+- Hard coding shared paths in multiple places.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+I/O becomes easier to test, but the abstractions must stay simple.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](032-separate-persisted-dtos-from-domain-objects.md) | [Next](038-use-messagepack-for-timeline-persistence.md)

--- a/Docs/Adr/persistence/038-use-messagepack-for-timeline-persistence.md
+++ b/Docs/Adr/persistence/038-use-messagepack-for-timeline-persistence.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](037-keep-file-access-behind-file-manager-abstractions.md)
+
+## [038] Use MessagePack For Timeline Persistence
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+This decision concerns a durable data contract rather than a single persistence technique. The file format and the boundary between domain objects and persisted DTOs must survive not only a single export, but also later reads and code evolution.
+
+**Problem:**
+
+The timeline can be large, so a text format would be expensive to persist and read.
+The problem is not just the persistence file itself, but also format compatibility, the boundary between runtime models and persisted data, and the cost of reading on later runs.
+
+**Decision:**
+
+Timeline data is serialized in binary form through MessagePack.
+This decision keeps persistence as a separate layer with an explicit data contract and control over what is written to disk versus what remains a runtime implementation detail.
+
+**Rejected:** 
+
+- JSON as the main runtime persistence format.
+- A custom unproven binary format.
+- Tightly coupling the file format to the current shape of runtime objects.
+- Treating persistence as a side effect of export without a separate data contract.
+
+**Consequences:**
+
+Files stay compact and fast, but manual readability is lower and DTOs are required.
+The result is a durable file contract that must be treated carefully when changing DTOs, formatters, and timeline repository behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](037-keep-file-access-behind-file-manager-abstractions.md)

--- a/Docs/Adr/persistence/README.md
+++ b/Docs/Adr/persistence/README.md
@@ -1,0 +1,28 @@
+[ADR Home](../README.md)
+
+# persistence
+
+This category describes durable data contracts and the persistence model around `.gittrace` and related DTOs.
+
+## Scope
+
+Look here for questions about storage formats, MessagePack mapping, DTO boundaries, and file level persistence concerns.
+
+## Responsibility Boundaries
+
+Persistence owns durable representations and I/O contracts. It should not redefine domain meaning or provider behavior.
+
+## How To Start Reading
+
+Start here when changing serialized formats, DTOs, or persistence oriented file access.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [017-optimize-gittrace-serialization-hot-paths.md](./017-optimize-gittrace-serialization-hot-paths.md) | Optimize gittrace Serialization Hot Paths |
+| [018-persist-timelines-as-portable-gittrace-files.md](./018-persist-timelines-as-portable-gittrace-files.md) | Persist Timelines As Portable gittrace Files |
+| [019-use-streaming-serializers-for-gittrace-writes.md](./019-use-streaming-serializers-for-gittrace-writes.md) | Use Streaming Serializers For gittrace Writes |
+| [032-separate-persisted-dtos-from-domain-objects.md](./032-separate-persisted-dtos-from-domain-objects.md) | Separate Persisted DTOs From Domain Objects |
+| [037-keep-file-access-behind-file-manager-abstractions.md](./037-keep-file-access-behind-file-manager-abstractions.md) | Keep File Access Behind File Manager Abstractions |
+| [038-use-messagepack-for-timeline-persistence.md](./038-use-messagepack-for-timeline-persistence.md) | Use MessagePack For Timeline Persistence |

--- a/Docs/Adr/player/039-drive-playback-through-a-separate-transport.md
+++ b/Docs/Adr/player/039-drive-playback-through-a-separate-transport.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](040-keep-seeking-in-a-dedicated-timeline-service.md)
+
+## [039] Drive Playback Through A Separate Transport
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`PlaybackTransport` maintains the `Idle/Playing/Paused` state, emits ticks, and manages the timer. `TimelinePlayer` subscribes to those ticks and performs cursor draining and boundary handling on them, but it does not run the timing loop itself.
+
+**Problem:**
+
+Controlling playback flow and processing events are not the same responsibility. When one class both schedules ticks and executes playback logic on them, it becomes harder to isolate real time errors from player semantics errors.
+
+**Decision:**
+
+The tick loop and transport state transitions are separated into a dedicated transport. The player reacts to transport ticks, but it does not manage the timer or `Play/Pause/Stop` transitions directly.
+
+**Rejected:**
+
+- Embedding the `Timer` loop directly in `TimelinePlayer`.
+- Updating playback only when the renderer or graphics window is invoked.
+- Mixing transport state with boundary handling and seeking.
+- Replacing explicit transport with ad hoc external polling.
+
+**Consequences:**
+
+Transport and player can be tested separately, and playback can stay outside the graphics layer. The cost is maintaining two state layers that must remain consistent: transport state and the logical state reported by the player.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](040-keep-seeking-in-a-dedicated-timeline-service.md)

--- a/Docs/Adr/player/040-keep-seeking-in-a-dedicated-timeline-service.md
+++ b/Docs/Adr/player/040-keep-seeking-in-a-dedicated-timeline-service.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](039-drive-playback-through-a-separate-transport.md) | [Next](041-model-playback-boundary-behavior-explicitly.md)
+
+## [040] Keep Seeking In A Dedicated Timeline Service
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`SeekableTimeline` ties together `IVirtualClock` and `IEventCursor`, handles position clamping, moves the cursor, and publishes progress. `TimelinePlayer` delegates `Seek` and `SeekRelative` to it without taking on the time and index repositioning details.
+
+**Problem:**
+
+Seeking changes two states at the same time: the virtual time position and the cursor position in the event stream. When those operations are scattered across the player or the calling layer, it is easy to create inconsistency between the reported position and the next event to be played.
+
+**Decision:**
+
+Seeking is maintained in a dedicated timeline service that treats the clock and cursor as one repositioning operation. The player consumes a ready made `ISeekable` contract instead of assembling seek logic itself.
+
+**Rejected:**
+
+- Modifying only the cursor without updating virtual time.
+- Modifying only the virtual clock without repositioning the cursor.
+- Implementing `Seek` directly in `TimelinePlayer`.
+- Leaving position clamping and progress emission to the calling layer.
+
+**Consequences:**
+
+After a seek, the player has a consistent resume point and a stable progress contract. The tradeoff is that every change in seek semantics touches a central component used by the stepper, diagnostics, and later rendering.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](039-drive-playback-through-a-separate-transport.md) | [Next](041-model-playback-boundary-behavior-explicitly.md)

--- a/Docs/Adr/player/041-model-playback-boundary-behavior-explicitly.md
+++ b/Docs/Adr/player/041-model-playback-boundary-behavior-explicitly.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](040-keep-seeking-in-a-dedicated-timeline-service.md) | [Next](042-use-a-virtual-clock-for-playback.md)
+
+## [041] Model Playback Boundary Behavior Explicitly
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define the model of time and timeline navigation. The player is not meant to be just an iterator over an event list, but a separate layer capable of seeking, speed control, pausing, and diagnostics without depending on a specific rendering backend.
+
+**Problem:**
+
+After reaching the end of the timeline, the application can stop, loop, or reverse direction.
+The player cannot be just a loop that advances an index, because playback has to be controllable, deterministic, and independent from the rendering backend.
+
+**Decision:**
+
+Boundary behavior is modeled through dedicated handlers.
+These decisions establish a separate model of time, navigation, and diagnostics that rendering and debug tooling consume later.
+
+**Rejected:**
+
+- One hard coded reaction to the end of the timeline.
+- Spreading boundary conditions across the player.
+- Coupling the playback model directly to frame rate or the system clock.
+- Splitting seeking, timekeeping, and boundary behavior across several inconsistent components.
+
+**Consequences:**
+
+Playback modes become extensible, but each one requires tests.
+This gives playback a stable contract and makes it testable without graphics, but any change to timekeeping or seeking affects several layers at once.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](040-keep-seeking-in-a-dedicated-timeline-service.md) | [Next](042-use-a-virtual-clock-for-playback.md)

--- a/Docs/Adr/player/042-use-a-virtual-clock-for-playback.md
+++ b/Docs/Adr/player/042-use-a-virtual-clock-for-playback.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](041-model-playback-boundary-behavior-explicitly.md) | [Next](043-use-event-cursors-for-timeline-navigation.md)
+
+## [042] Use A Virtual Clock For Playback
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define the model of time and timeline navigation. The player is not meant to be just an iterator over an event list, but a separate layer capable of seeking, speed control, pausing, and diagnostics without depending on a specific rendering backend.
+
+**Problem:**
+
+Playback must be deterministic and controllable, independent from system time.
+The player cannot be just a loop that advances an index, because playback has to be controllable, deterministic, and independent from the rendering backend.
+
+**Decision:**
+
+The player uses a virtual clock.
+These decisions establish a separate model of time, navigation, and diagnostics that rendering and debug tooling consume later.
+
+**Rejected:**
+
+- Using `DateTime.Now` as the source of truth for playback time.
+- Controlling time from the renderer loop.
+- Coupling the playback model directly to frame rate or the system clock.
+- Splitting seeking, timekeeping, and boundary behavior across several inconsistent components.
+
+**Consequences:**
+
+Playback tests become simpler, and the presentation layer can pause and scrub time.
+This gives playback a stable contract and makes it testable without graphics, but any change to timekeeping or seeking affects several layers at once.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](041-model-playback-boundary-behavior-explicitly.md) | [Next](043-use-event-cursors-for-timeline-navigation.md)

--- a/Docs/Adr/player/043-use-event-cursors-for-timeline-navigation.md
+++ b/Docs/Adr/player/043-use-event-cursors-for-timeline-navigation.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](042-use-a-virtual-clock-for-playback.md) | [Next](044-compose-players-from-specialized-playback-components.md)
+
+## [043] Use Event Cursors For Timeline Navigation
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define the model of time and timeline navigation. The player is not meant to be just an iterator over an event list, but a separate layer capable of seeking, speed control, pausing, and diagnostics without depending on a specific rendering backend.
+
+**Problem:**
+
+Playback requires event traversal, seeking, and explicit boundary handling.
+The player cannot be just a loop that advances an index, because playback has to be controllable, deterministic, and independent from the rendering backend.
+
+**Decision:**
+
+Timeline navigation goes through an event cursor and a seekable timeline.
+This keeps navigation, boundary checks, and repositioning behavior inside a dedicated playback model that rendering and debug tooling can consume later.
+
+**Rejected:**
+
+- Ad hoc iteration over event lists.
+- Letting each consumer implement its own seeking behavior.
+- Coupling the playback model directly to frame rate or the system clock.
+- Splitting seeking, timekeeping, and boundary behavior across several inconsistent components.
+
+**Consequences:**
+
+The player gets a stable navigation contract, but cursor behavior has to handle boundary conditions explicitly.
+This gives playback a stable contract and makes it testable without graphics, but any change to timekeeping or seeking affects several layers at once.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](042-use-a-virtual-clock-for-playback.md) | [Next](044-compose-players-from-specialized-playback-components.md)

--- a/Docs/Adr/player/044-compose-players-from-specialized-playback-components.md
+++ b/Docs/Adr/player/044-compose-players-from-specialized-playback-components.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](043-use-event-cursors-for-timeline-navigation.md) | [Next](045-derive-playback-duration-from-active-repository-days.md)
+
+## [044] Compose Players From Specialized Playback Components
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The player in code is not a single object implementing the entire playback flow from start to finish. `TimelinePlayerFactory` composes instances from `VirtualClock`, `EventCursor`, `SeekableTimeline`, `PlaybackTransport`, and `TimelinePlayer` itself, while orchestration remains in the player layer.
+
+**Problem:**
+
+Full playback combines several different axes of responsibility: virtual time, navigation through events, transport, seeking, and diagnostics. Collapsing all of that into one class makes testing harder and blurs the boundary between time state, cursor state, and playback control.
+
+**Decision:**
+
+The player is composed from specialized components, each with its own contract. `TimelinePlayer` remains a coordinator rather than the place where every playback detail is implemented.
+
+**Rejected:**
+
+- A monolithic `TimelinePlayer` containing the clock, seeking, transport, and cursor.
+- Constructing player dependencies directly in `Program.cs` or inside the graphics window.
+- Building new player variants through inheritance instead of composing behavior from components.
+- Spreading player composition across many runtime layers without one factory boundary.
+
+**Consequences:**
+
+Playback ends up with more objects and more explicit contracts, but changes in seeking, the clock, or transport do not require rewriting the whole player. The factory becomes the place where timeline normalization, duration calculation, and default playback configuration have to stay aligned.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](043-use-event-cursors-for-timeline-navigation.md) | [Next](045-derive-playback-duration-from-active-repository-days.md)

--- a/Docs/Adr/player/045-derive-playback-duration-from-active-repository-days.md
+++ b/Docs/Adr/player/045-derive-playback-duration-from-active-repository-days.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](044-compose-players-from-specialized-playback-components.md) | [Next](046-expose-playback-diagnostics.md)
+
+## [045] Derive Playback Duration From Active Repository Days
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`TimelineDurationCalculator` does not base playback time on raw event count or the full date range. Playback duration is derived from the number of active days and then clamped to minimum and maximum session lengths.
+
+**Problem:**
+
+Repository histories are uneven: long periods without changes should not automatically stretch playback, and very dense days should not compress it into unreadable flicker. The player needs one time scale that stabilizes playback duration across different timelines.
+
+**Decision:**
+
+Playback duration is derived from the number of active days in repository history, with explicit `secondsPerDay`, `minDuration`, and `maxDuration` limits. Timeline normalization is performed relative to that target duration before the player starts.
+
+**Rejected:**
+
+- Playback duration proportional to the total number of events.
+- Making duration proportional to the full calendar range, including inactive periods.
+- No upper or lower bound for very short or very long histories.
+- Choosing duration only in the renderer or HUD layer.
+
+**Consequences:**
+
+Different repositories get a more comparable playback session length, and seek plus diagnostics operate on one time scale. The downside is that playback time becomes a deliberate interpretation of history rather than a simple reflection of raw calendar time.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](044-compose-players-from-specialized-playback-components.md) | [Next](046-expose-playback-diagnostics.md)

--- a/Docs/Adr/player/046-expose-playback-diagnostics.md
+++ b/Docs/Adr/player/046-expose-playback-diagnostics.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](045-derive-playback-duration-from-active-repository-days.md) | [Next](047-normalize-timeline-time-before-playback.md)
+
+## [046] Expose Playback DIagnostics
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+These decisions define the model of time and timeline navigation. The player is not meant to be just an iterator over an event list, but a separate layer capable of seeking, speed control, pausing, and diagnostics without depending on a specific rendering backend.
+
+**Problem:**
+
+Debugging the player requires visible time, cursor, and transport state.
+The player cannot be just a loop that advances an index, because playback has to be controllable, deterministic, and independent from the rendering backend.
+
+**Decision:**
+
+The player publishes a diagnostic snapshot.
+These decisions establish a separate model of time, navigation, and diagnostics that rendering and debug tooling consume later.
+
+**Rejected:**
+
+- Debugging only through logs.
+- Reading private player state through the presentation layer.
+- Coupling the playback model directly to frame rate or the system clock.
+- Splitting seeking, timekeeping, and boundary behavior across several inconsistent components.
+
+**Consequences:**
+
+Diagnostics become more stable, but the snapshot must be updated when player state changes.
+This gives playback a stable contract and makes it testable without graphics, but any change to timekeeping or seeking affects several layers at once.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](045-derive-playback-duration-from-active-repository-days.md) | [Next](047-normalize-timeline-time-before-playback.md)

--- a/Docs/Adr/player/047-normalize-timeline-time-before-playback.md
+++ b/Docs/Adr/player/047-normalize-timeline-time-before-playback.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](046-expose-playback-diagnostics.md) | [Next](048-ramp-playback-speed-toward-target-values.md)
+
+## [047] Normalize Timeline Time Before Playback
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+These decisions define the model of time and timeline navigation. The player is not meant to be just an iterator over an event list, but a separate layer capable of seeking, speed control, pausing, and diagnostics without depending on a specific rendering backend.
+
+**Problem:**
+
+The date range in repository history does not map directly to playback pace.
+The player cannot be just a loop that advances an index, because playback has to be controllable, deterministic, and independent from the rendering backend.
+
+**Decision:**
+
+The timeline is normalized into relative time before playback.
+These decisions establish a separate model of time, navigation, and diagnostics that rendering and debug tooling consume later.
+
+**Rejected:**
+
+- Playback based on absolute dates.
+- Scaling time in the renderer.
+- Coupling the playback model directly to frame rate or the system clock.
+- Splitting seeking, timekeeping, and boundary behavior across several inconsistent components.
+
+**Consequences:**
+
+The player behaves predictably, but normalization must stay aligned with seek behavior and speed control.
+This gives playback a stable contract and makes it testable without graphics, but any change to timekeeping or seeking affects several layers at once.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](046-expose-playback-diagnostics.md) | [Next](048-ramp-playback-speed-toward-target-values.md)

--- a/Docs/Adr/player/048-ramp-playback-speed-toward-target-values.md
+++ b/Docs/Adr/player/048-ramp-playback-speed-toward-target-values.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](047-normalize-timeline-time-before-playback.md) | [Next](049-support-single-event-stepping-separately-from-continuous-playback.md)
+
+## [048] Ramp Playback Speed Toward Target Values
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`VirtualClock` delegates speed dynamics to `SpeedController`, which maintains `CurrentSpeed`, `TargetSpeed`, acceleration, and ramp state reanchoring. In code, playback speed is not just one number but the progression toward a target value.
+
+**Problem:**
+
+An immediate speed change is simple to implement, but it breaks virtual time continuity and makes resume behavior after pause, speed changes, or seek less predictable. The player needs a model in which speed changes do not corrupt time position or diagnostics.
+
+**Decision:**
+
+Target speed changes happen through acceleration based ramping rather than direct jumps. Immediate jumps remain only for operations explicitly treated as snaps, such as preset speed or freeze.
+
+**Rejected:**
+
+- One speed value without distinguishing between `current` and `target`.
+- Applying immediate speed changes for every control call.
+- Calculating speed in the transport instead of in the virtual clock.
+- Keeping ramping logic in the rendering or input layer.
+
+**Consequences:**
+
+Playback preserves time continuity and handles pause/resume and target speed changes better. The tradeoff is a more complex speed model, and diagnostics and tests must distinguish the current ramp state from the target value.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](047-normalize-timeline-time-before-playback.md) | [Next](049-support-single-event-stepping-separately-from-continuous-playback.md)

--- a/Docs/Adr/player/049-support-single-event-stepping-separately-from-continuous-playback.md
+++ b/Docs/Adr/player/049-support-single-event-stepping-separately-from-continuous-playback.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](048-ramp-playback-speed-toward-target-values.md)
+
+## [049] Support Single Event Stepping Separately From Continuous Playback
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The player code distinguishes between two timeline advance modes: continuous playback driven by ticks and single event stepping through `TimelineStepper`. The stepper updates the cursor, moves the clock to the event time, and can emit an event without starting the transport.
+
+**Problem:**
+
+Debugging, precise navigation, and paused playback need single event stepping rather than only time flowing with transport ticks. When stepping is treated as a special case of `Play`, it becomes hard to preserve precision and predictable emitted events.
+
+**Decision:**
+
+Stepping through the timeline is modeled as a separate operation over the cursor and clock, independent from continuous playback. `TimelinePlayer` exposes `StepForward` and `StepBackward`, but delegates their semantics to a dedicated stepper.
+
+**Rejected:**
+
+- Simulating stepping by briefly starting the transport and pausing it immediately.
+- Allowing external layers to perform stepping through direct cursor access.
+- Combining stepping with seeking without a dedicated per event contract.
+- Emitting step events without updating virtual time.
+
+**Consequences:**
+
+The player has a stable navigation model both for continuous playback and for step by step debugging. The cost is that stepping semantics must remain aligned with the cursor, seeking, and diagnostics, otherwise those three axes will start reporting different timeline positions.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](048-ramp-playback-speed-toward-target-values.md)

--- a/Docs/Adr/player/README.md
+++ b/Docs/Adr/player/README.md
@@ -1,0 +1,33 @@
+[ADR Home](../README.md)
+
+# player
+
+This category describes the playback model for timelines: time, navigation, boundaries, and diagnostics.
+
+## Scope
+
+Look here for virtual time, event cursors, seeking, speed control, transport, stepping, and playback diagnostics.
+
+## Responsibility Boundaries
+
+The player is not the renderer and not the graphics runtime. It owns temporal semantics and event activation.
+
+## How To Start Reading
+
+Start here when changing playback semantics, seeking, timing, or transport behavior.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [039-drive-playback-through-a-separate-transport.md](./039-drive-playback-through-a-separate-transport.md) | Drive Playback Through A Separate Transport |
+| [040-keep-seeking-in-a-dedicated-timeline-service.md](./040-keep-seeking-in-a-dedicated-timeline-service.md) | Keep Seeking In A Dedicated Timeline Service |
+| [041-model-playback-boundary-behavior-explicitly.md](./041-model-playback-boundary-behavior-explicitly.md) | Model Playback Boundary Behavior Explicitly |
+| [042-use-a-virtual-clock-for-playback.md](./042-use-a-virtual-clock-for-playback.md) | Use A Virtual Clock For Playback |
+| [043-use-event-cursors-for-timeline-navigation.md](./043-use-event-cursors-for-timeline-navigation.md) | Use Event Cursors For Timeline Navigation |
+| [044-compose-players-from-specialized-playback-components.md](./044-compose-players-from-specialized-playback-components.md) | Compose Players From Specialized Playback Components |
+| [045-derive-playback-duration-from-active-repository-days.md](./045-derive-playback-duration-from-active-repository-days.md) | Derive Playback Duration From Active Repository Days |
+| [046-expose-playback-diagnostics.md](./046-expose-playback-diagnostics.md) | Expose Playback DIagnostics |
+| [047-normalize-timeline-time-before-playback.md](./047-normalize-timeline-time-before-playback.md) | Normalize Timeline Time Before Playback |
+| [048-ramp-playback-speed-toward-target-values.md](./048-ramp-playback-speed-toward-target-values.md) | Ramp Playback Speed Toward Target Values |
+| [049-support-single-event-stepping-separately-from-continuous-playback.md](./049-support-single-event-stepping-separately-from-continuous-playback.md) | Support Single Event Stepping Separately From Continuous Playback |

--- a/Docs/Adr/providers/020-keep-provider-specific-enrichment-behind-interfaces.md
+++ b/Docs/Adr/providers/020-keep-provider-specific-enrichment-behind-interfaces.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](021-make-enrichment-optional-per-export.md)
+
+## [020] Keep Provider Specific Enrichment Behind Interfaces
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Pull requests, merge metadata, and host specific repository details come from APIs that differ materially across GitHub, GitLab, Codeberg, and custom providers. The export pipeline needs those enrichments, but the base timeline and exporter orchestration should not depend on one hosting API shape.
+
+**Problem:**
+
+If provider specific enrichment logic sits directly in the exporter, every host capability difference leaks into staging, retry behavior, diagnostics, and command handling. That makes the common export path harder to extend and turns host support into conditionals scattered across unrelated modules.
+
+**Decision:**
+
+Provider specific enrichment is implemented behind shared interfaces. The exporter depends on enrichment contracts and provider resolution, while each host integration owns its own API calls, capability rules, and mapping into the enrichment model.
+
+**Rejected:**
+
+- One GitHub centric enricher used as the default model for every provider.
+- Putting provider conditions directly in `RepositoryExporter`.
+- Flattening all providers to the same lowest common denominator at the cost of losing their real constraints.
+- Spreading provider specific logic across the exporter, prompts, auth flows, and history reading layers.
+
+**Consequences:**
+
+Adding or changing provider integrations becomes more localized, and the exporter can stay focused on orchestration. The cost is that interface design and provider resolution become important contracts that have to stay aligned with host capability differences.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](021-make-enrichment-optional-per-export.md)

--- a/Docs/Adr/providers/021-make-enrichment-optional-per-export.md
+++ b/Docs/Adr/providers/021-make-enrichment-optional-per-export.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](020-keep-provider-specific-enrichment-behind-interfaces.md) | [Next](022-skip-unavailable-github-pr-data-without-failing-export.md)
+
+## [021] Make Enrichment Optional Per Export
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Repository export can succeed without host enrichment, but enrichment may still be useful for pull request timelines, merge analysis, and richer sidecars. Different export runs also have different tolerance for API latency, auth requirements, and external failures.
+
+**Problem:**
+
+Treating enrichment as mandatory forces every export through the slowest and least reliable part of the pipeline, even when the operator only needs the base timeline. It also removes control over failure modes when provider APIs are unavailable or unnecessary for the current run.
+
+**Decision:**
+
+Enrichment is selectable per export through explicit options and prompts. The exporter receives a clear enrichment scope and can skip provider work entirely when the selected mode does not require it.
+
+**Rejected:**
+
+- Always attempting full enrichment.
+- Hiding enrichment from the calling layer.
+- Binding enrichment policy permanently to one repository or workspace setting.
+- Deriving enrichment behavior implicitly from whichever provider credentials happen to be available.
+
+**Consequences:**
+
+Export cost, speed, and risk become controllable at runtime, and automated invocations can choose a narrower scope deliberately. The tradeoff is that CLI and exporter contracts must carry explicit enrichment intent instead of assuming one universal export mode.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](020-keep-provider-specific-enrichment-behind-interfaces.md) | [Next](022-skip-unavailable-github-pr-data-without-failing-export.md)

--- a/Docs/Adr/providers/022-skip-unavailable-github-pr-data-without-failing-export.md
+++ b/Docs/Adr/providers/022-skip-unavailable-github-pr-data-without-failing-export.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](021-make-enrichment-optional-per-export.md) | [Next](023-treat-unavailable-enrichment-as-degraded-mode.md)
+
+## [022] Skip Unavailable GitHub Pr Data Without Failing Export
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+GitHub pull request enrichment is useful but sits outside the core Git history path. The exporter can still build and persist a valid timeline when GitHub metadata is missing, stale, or inaccessible for a subset of commits.
+
+**Problem:**
+
+GitHub PR lookups can return `404` or otherwise fail even when repository history is readable and the base export is valid. Treating that case as a fatal export error couples optional enrichment to the success semantics of the main artifact.
+
+**Decision:**
+
+Unavailable GitHub PR data is skipped without failing the export. The exporter records the absence as an optional enrichment outcome and continues producing the main timeline plus any other artifacts that remain valid.
+
+**Rejected:**
+
+- Failing the export because the PR sidecar is missing.
+- Retrying the same missing data case on every resume.
+- Treating every GitHub API miss as evidence of exporter corruption.
+- Hiding the skipped enrichment outcome entirely from diagnostics and resume state.
+
+**Consequences:**
+
+Repositories with unavailable PR data still produce `.gittrace`, which keeps the base export useful under partial API failure. The cost is that downstream consumers must tolerate missing PR sidecars and diagnostics must make the degraded outcome explicit.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](021-make-enrichment-optional-per-export.md) | [Next](023-treat-unavailable-github-pr-data-without-failing-export.md)

--- a/Docs/Adr/providers/023-treat-unavailable-enrichment-as-degraded-mode.md
+++ b/Docs/Adr/providers/023-treat-unavailable-enrichment-as-degraded-mode.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](022-skip-unavailable-github-pr-data-without-failing-export.md) | [Next](033-support-provider-aware-login-flows.md)
+
+## [023] Treat Unavailable Enrichment As Degraded Mode
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Host enrichment extends the export model, but it is not the same thing as the core timeline derived from Git history. The exporter needs a way to represent partial success when optional provider data is missing while the main artifact remains valid.
+
+**Problem:**
+
+Without an explicit degraded mode model, the exporter has only two outcomes: full success or hard failure. That forces optional host data into the same success semantics as core timeline persistence and makes retries, diagnostics, and resume behavior harder to reason about.
+
+**Decision:**
+
+Unavailable enrichment is represented as degraded mode when the main export can still complete. The exporter and related diagnostics distinguish between a valid base timeline with missing optional data and a genuine export failure.
+
+**Rejected:**
+
+- Failing fast for every unavailable provider datum.
+- Silently skipping enrichment without signaling the outcome to the caller.
+- Treating degraded exports as indistinguishable from fully enriched exports.
+- Encoding degraded state only in logs with no effect on exporter outcome metadata.
+
+**Consequences:**
+
+Export becomes more resilient and resume behavior becomes easier to reason about under partial host failure. The tradeoff is that consumers, tests, and diagnostics have to understand one more success state beyond simple pass/fail.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](022-skip-unavailable-github-pr-data-without-failing-export.md) | [Next](033-support-provider-aware-login-flows.md)

--- a/Docs/Adr/providers/033-support-provider-aware-login-flows.md
+++ b/Docs/Adr/providers/033-support-provider-aware-login-flows.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](023-treat-unavailable-enrichment-as-degraded-mode.md) | [Next](053-use-provider-detection-from-repository-urls.md)
+
+## [033] Support Provider Aware Login Flows
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Different hosting providers expose different authentication capabilities: device flow, browser redirect with PKCE, custom OIDC discovery, or no support for a given flow at all. The CLI cannot treat login as one uniform exchange while still supporting those hosts cleanly.
+
+**Problem:**
+
+If login is modeled as one global flow, the system either overfits to one provider or degrades every integration to the weakest common behavior. That makes auth handling brittle and pushes provider capability checks into CLI commands and session setup.
+
+**Decision:**
+
+Login chooses a provider specific flow instead of one global scheme. Provider selection determines which auth contract is used, and the resulting session still lands in the shared local auth model.
+
+**Rejected:**
+
+- One GitHub device flow implementation for every provider.
+- Token only auth for providers without device flow.
+- Flattening all providers to the same lowest common denominator at the cost of losing their real constraints.
+- Spreading provider specific logic across the exporter, prompts, auth flows, and history reading layers.
+
+**Consequences:**
+
+Auth support becomes more flexible and host integrations can use the flows they actually support. The cost is that capability detection and prompt behavior must stay aligned with provider specific auth implementations.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](023-treat-unavailable-enrichment-as-degraded-mode.md) | [Next](053-use-provider-detection-from-repository-urls.md)

--- a/Docs/Adr/providers/053-use-provider-detection-from-repository-urls.md
+++ b/Docs/Adr/providers/053-use-provider-detection-from-repository-urls.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](033-support-provider-aware-login-flows.md) | [Next](093-resolve-timeline-enrichers-by-provider.md)
+
+## [053] Use Provider Detection From Repository Urls
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The export and auth layers both need to know which hosting rules apply before they can choose enrichers, prompts, or login flows. Repository URLs already encode that information for the common cases, so the system has a natural signal for provider selection.
+
+**Problem:**
+
+If the provider has to be passed manually everywhere, repository driven workflows become noisy and easy to misconfigure. If the system assumes one default host, provider aware auth and enrichment become wrong as soon as the repository comes from another platform.
+
+**Decision:**
+
+The provider is resolved from the repository URL through a shared helper. That provider identity becomes the common input for auth selection, enrichment resolution, and related host specific behavior.
+
+**Rejected:**
+
+- Passing the provider manually in every situation.
+- Assuming GitHub for every URL.
+- Keeping separate provider detection logic in auth, export, and CLI layers.
+- Falling back to provider specific heuristics scattered through repository processing code.
+
+**Consequences:**
+
+Provider aware auth and enrichment share one entry point, and repository driven workflows become easier to automate. The tradeoff is that URL parsing rules become a central compatibility surface that needs explicit tests for host variants and edge cases.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](033-support-provider-aware-login-flows.md) | [Next](093-resolve-timeline-enrichers-by-provider.md)

--- a/Docs/Adr/providers/093-resolve-timeline-enrichers-by-provider.md
+++ b/Docs/Adr/providers/093-resolve-timeline-enrichers-by-provider.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](053-use-provider-detection-from-repository-urls.md) | [Next](094-use-device-flow-where-providers-support-it.md)
+
+## [093] Resolve Timeline Enrichers By Provider
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Once provider identity is known, the export pipeline still has to choose the correct enrichment implementation for the current host and selected export scope. That choice belongs in one resolver instead of in exporter conditionals.
+
+**Problem:**
+
+The exporter needs to resolve the correct enricher from provider identity and active call configuration. Without a dedicated resolution point, host selection logic leaks into export stages and makes unsupported provider behavior harder to centralize.
+
+**Decision:**
+
+Enricher selection goes through a provider aware resolver. The exporter asks for the matching enrichment implementation and then executes a host specific path without encoding provider branches locally.
+
+**Rejected:**
+
+- Manual `if/else` branching in the export path.
+- Providing no enrichment for providers other than GitHub.
+- Resolving enrichers ad hoc inside CLI handlers before export starts.
+- Hiding unsupported provider behavior behind null returns with no explicit policy.
+
+**Consequences:**
+
+Export stays extensible and provider support becomes easier to add in one place. The tradeoff is that the resolver becomes a key contract for unsupported cases, fallback policy, and host specific scope handling.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](053-use-provider-detection-from-repository-urls.md) | [Next](094-use-device-flow-where-providers-support-it.md)

--- a/Docs/Adr/providers/094-use-device-flow-where-providers-support-it.md
+++ b/Docs/Adr/providers/094-use-device-flow-where-providers-support-it.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](093-resolve-timeline-enrichers-by-provider.md) | [Next](095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md)
+
+## [094] Use Device Flow Where Providers Support It
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+GitHub and GitLab offer device flow that fits a CLI well because it avoids local callback plumbing and still preserves a standards based authorization path. For a local first command line application, that tradeoff is often better than forcing a browser redirect listener when the provider does not require it.
+
+**Problem:**
+
+CLI login should avoid unnecessary local callback infrastructure when a provider already supports a safer out of band authorization mechanism. For providers with device flow, using a more complex flow adds operational friction without buying better integration.
+
+**Decision:**
+
+GitHub and GitLab use device flow. The provider layer selects that auth path when it is supported, while other providers can still use different flows through the same auth architecture.
+
+**Rejected:**
+
+- Making browser callback flow the default for every provider.
+- Using pasted personal access tokens as the primary login mode.
+- Treating device flow as a custom CLI shortcut outside the common auth abstractions.
+- Pretending all providers support the same login mechanism.
+
+**Consequences:**
+
+CLI login becomes simpler for supported providers and avoids running local callback infrastructure unnecessarily. The tradeoff is that auth behavior now depends on provider capability, which has to remain visible in prompts, docs, and tests.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](093-resolve-timeline-enrichers-by-provider.md) | [Next](095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md)

--- a/Docs/Adr/providers/095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md
+++ b/Docs/Adr/providers/095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](094-use-device-flow-where-providers-support-it.md) | [Next](096-use-authorization-code-pkce-for-oidc-providers.md)
+
+## [095] Support Custom OIDC Providers Through Dynamic Discovery And Local Callbacks
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+The provider layer is not limited to built in integrations such as GitHub or GitLab. `CustomOAuthProvider` introduces a `custom` model based on OIDC discovery, a local HTTP callback, PKCE, and a named `provider key`, allowing auth to work with non standard issuers without hardcoding them into the codebase.
+
+**Problem:**
+
+The system has to support a provider that is not known at compile time while still fitting into the same auth session model and provider aware workflow. Without an explicit dynamic discovery decision, auth would tend to hard code a few integrations or split custom login away from the rest of the provider contracts.
+
+**Decision:**
+
+ChangeTrace supports custom OIDC providers through dynamic discovery document retrieval, a local callback listener, and a named session key of `custom:<slug>`. A custom provider stays inside the same auth architecture as the built in integrations, but with a different input configuration model.
+
+**Rejected:**
+
+- Supporting only a fixed list of built in providers.
+- Keeping custom provider endpoints as fixed code configuration without discovery.
+- Requiring an external callback service instead of a local redirect listener.
+- Splitting custom OIDC into a separate auth path without a shared `IAuthProvider` contract.
+
+**Consequences:**
+
+The system becomes more flexible for new issuers and self hosted installations, and custom auth does not require a new integration per provider. The tradeoff is a more complex model for input validation, local callbacks, and dynamically named sessions.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](094-use-device-flow-where-providers-support-it.md) | [Next](096-use-authorization-code-pkce-for-oidc-providers.md)

--- a/Docs/Adr/providers/096-use-authorization-code-pkce-for-oidc-providers.md
+++ b/Docs/Adr/providers/096-use-authorization-code-pkce-for-oidc-providers.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md)
+
+## [096] Use Authorization Code PKCE For OIDC Providers
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+Not every provider offers device flow, and custom OIDC integrations need a standards based browser driven authorization path. Codeberg and dynamic OIDC providers fit that model better than token paste or device code behavior.
+
+**Problem:**
+
+For providers without device flow, the CLI still needs a secure user authorization path that works with public clients and does not rely on long lived static secrets. Falling back to passwords or pasted long lived tokens would weaken the auth model and fragment session semantics.
+
+**Decision:**
+
+Codeberg and custom providers use authorization code flow with PKCE. The provider layer runs that flow through local callback handling and feeds the resulting session back into the shared auth model.
+
+**Rejected:**
+
+- Having no support for providers that do not offer device flow.
+- Using passwords or long lived tokens as a fallback.
+- Flattening all providers to the same lowest common denominator at the cost of losing their real constraints.
+- Treating OIDC redirect flow as a provider specific special case outside shared auth contracts.
+
+**Consequences:**
+
+The provider set can expand beyond device flow hosts while keeping a modern auth posture. The cost is additional callback, PKCE, and OIDC configuration complexity that has to remain validated and observable.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md)

--- a/Docs/Adr/providers/README.md
+++ b/Docs/Adr/providers/README.md
@@ -1,0 +1,32 @@
+[ADR Home](../README.md)
+
+# providers
+
+This category covers hosting provider dependent behavior such as detection, login, enrichment, and fallbacks.
+
+## Scope
+
+Look here for provider detection, provider aware auth, enrichment routing, and host specific capability differences.
+
+## Responsibility Boundaries
+
+Providers should not define the timeline model or the `.gittrace` format. This layer isolates host variability from the rest of the system.
+
+## How To Start Reading
+
+Start here for any change that depends on GitHub, GitLab, Codeberg, or custom OIDC behavior.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [020-keep-provider-specific-enrichment-behind-interfaces.md](./020-keep-provider-specific-enrichment-behind-interfaces.md) | Keep Provider Specific Enrichment Behind Interfaces |
+| [021-make-enrichment-optional-per-export.md](./021-make-enrichment-optional-per-export.md) | Make Enrichment Optional Per Export |
+| [022-skip-unavailable-github-pr-data-without-failing-export.md](./022-skip-unavailable-github-pr-data-without-failing-export.md) | Skip Unavailable GitHub Pr Data Without Failing Export |
+| [023-treat-unavailable-enrichment-as-degraded-mode.md](./023-treat-unavailable-enrichment-as-degraded-mode.md) | Treat Unavailable Enrichment As Degraded Mode |
+| [033-support-provider-aware-login-flows.md](./033-support-provider-aware-login-flows.md) | Support Provider Aware Login Flows |
+| [053-use-provider-detection-from-repository-urls.md](./053-use-provider-detection-from-repository-urls.md) | Use Provider Detection From Repository Urls |
+| [093-resolve-timeline-enrichers-by-provider.md](./093-resolve-timeline-enrichers-by-provider.md) | Resolve Timeline Enrichers By Provider |
+| [094-use-device-flow-where-providers-support-it.md](./094-use-device-flow-where-providers-support-it.md) | Use Device Flow Where Providers Support It |
+| [095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md](./095-support-custom-oidc-providers-through-dynamic-discovery-and-local-callbacks.md) | Support Custom OIDC Providers Through Dynamic Discovery And Local Callbacks |
+| [096-use-authorization-code-pkce-for-oidc-providers.md](./096-use-authorization-code-pkce-for-oidc-providers.md) | Use Authorization Code PKCE For OIDC Providers |

--- a/Docs/Adr/rendering/050-separate-rendering-core-from-graphics-runtime.md
+++ b/Docs/Adr/rendering/050-separate-rendering-core-from-graphics-runtime.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](051-translate-trace-events-into-render-commands.md)
+
+## [050] Separate Rendering Core From Graphics Runtime
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+The repository needs one layer that decides what should be visualized and another that decides how GPU and windowing code executes that plan. Scene state, layout, camera, and render commands change for different visualization policies even when the OpenGL backend stays the same.
+
+**Problem:**
+
+If rendering policy and graphics execution live in one layer, every scene level change drags in GPU runtime concerns and every backend change risks altering visualization semantics. That makes testing harder and ties scene evolution to a specific runtime implementation.
+
+**Decision:**
+
+Rendering core is kept separate from the graphics runtime. The rendering layer owns scene logic, translation, snapshots, and render state, while the graphics layer consumes that prepared state through a backend contract.
+
+**Rejected:**
+
+- One layer combining scene semantics and GPU execution.
+- Letting OpenTK types leak directly into scene and translation code.
+- Building visualization behavior straight from timeline events inside backend renderers.
+- Treating graphics runtime details as the natural home for layout and camera policy.
+
+**Consequences:**
+
+Scene logic can be tested and evolved independently from GPU execution, and backend changes stay more localized. The tradeoff is a larger boundary surface between rendering and graphics that has to remain coherent over time.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Next](051-translate-trace-events-into-render-commands.md)

--- a/Docs/Adr/rendering/051-translate-trace-events-into-render-commands.md
+++ b/Docs/Adr/rendering/051-translate-trace-events-into-render-commands.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](050-separate-rendering-core-from-graphics-runtime.md) | [Next](052-use-render-commands-as-visual-intent.md)
+
+## [051] Translate Trace Events Into Render Commands
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The timeline describes repository activity, but the renderer needs operations that can update scene state consistently across different event kinds. Translation sits between those two concerns and turns event meaning into something the scene can apply deterministically.
+
+**Problem:**
+
+If the renderer reads raw timeline events directly, visual policy ends up embedded in event handling branches spread across the pipeline. That makes it hard to introduce new visual behaviors without coupling them to timeline storage details.
+
+**Decision:**
+
+Trace events are translated into render commands through dedicated translators. Translators isolate event interpretation from scene mutation and let the renderer consume a visual operation layer instead of raw timeline history.
+
+**Rejected:**
+
+- Letting the renderer mutate scene state directly from `TraceEvent`.
+- Embedding visual fields into the base timeline model.
+- Building every visual rule as a special case branch inside the pipeline.
+- Treating translation as a thin naming layer without its own semantics.
+
+**Consequences:**
+
+Event interpretation becomes easier to extend and test separately from scene execution. The tradeoff is that translators become a central policy layer whose behavior must remain aligned with both the timeline model and the scene contracts.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](050-separate-rendering-core-from-graphics-runtime.md) | [Next](052-use-render-commands-as-visual-intent.md)

--- a/Docs/Adr/rendering/052-use-render-commands-as-visual-intent.md
+++ b/Docs/Adr/rendering/052-use-render-commands-as-visual-intent.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](051-translate-trace-events-into-render-commands.md) | [Next](055-order-event-translators-by-explicit-priority.md)
+
+## [052] Use Render Commands As Visual Intent
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The renderer needs operations such as actor movement, branch labels, particles, and PR badges, but those operations should remain meaningful even if the concrete graphics backend changes. Render commands provide a backend neutral vocabulary for those visual intentions.
+
+**Problem:**
+
+Without a command layer, scene updates either become direct backend calls or one oversized mutable visual state object with weak boundaries. Both options make it harder to route intent cleanly through translation, buffering, and scene updates.
+
+**Decision:**
+
+Render commands describe visual intent independently from the graphics backend. Translators emit commands, scene systems consume them, and backend specific code only deals with prepared render state later in the pipeline.
+
+**Rejected:**
+
+- Making OpenGL calls directly from translators.
+- One large visual state object without commands.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Mixing translator, layout, and rendering runtime responsibilities in one layer.
+
+**Consequences:**
+
+Multiple outputs remain possible and the renderer keeps a stable internal vocabulary for scene updates. The tradeoff is that the command layer and its dispatcher become core contracts that must stay synchronized with scene behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](051-translate-trace-events-into-render-commands.md) | [Next](055-order-event-translators-by-explicit-priority.md)

--- a/Docs/Adr/rendering/055-order-event-translators-by-explicit-priority.md
+++ b/Docs/Adr/rendering/055-order-event-translators-by-explicit-priority.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](052-use-render-commands-as-visual-intent.md) | [Next](056-keep-animation-as-a-subsystem.md)
+
+## [055] Order Event Translators By Explicit Priority
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`TranslationPipeline` maintains a list of translators with explicit execution priority. Translators are registered separately, filtered by event type, and executed in a defined order instead of relying on accidental registration order or DI behavior.
+
+**Problem:**
+
+There can be more than one translator for a given event class, and the order of emitted commands matters for scene semantics. Without explicit ordering, translators become unstable and the resulting scene depends on initialization details instead of a declarative contract.
+
+**Decision:**
+
+The translation pipeline runs translators according to explicit priority while preserving `EventType` and `CanHandle` filtering. Translation order is treated as part of the rendering contract rather than an initialization detail.
+
+**Rejected:**
+
+- Relying on DI container registration order.
+- One translator containing all logic for every semantic event type.
+- Sorting dynamically by type names or other indirect heuristics.
+- Moving responsibility for command ordering into scene dispatchers.
+
+**Consequences:**
+
+Translator behavior becomes more predictable and new translators are easier to add without hidden side effects. The downside is that priorities must be maintained deliberately as part of the architecture rather than as incidental configuration.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](052-use-render-commands-as-visual-intent.md) | [Next](056-keep-animation-as-a-subsystem.md)

--- a/Docs/Adr/rendering/056-keep-animation-as-a-subsystem.md
+++ b/Docs/Adr/rendering/056-keep-animation-as-a-subsystem.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](055-order-event-translators-by-explicit-priority.md) | [Next](057-maintain-a-scene-graph-for-visualization-state.md)
+
+## [056] Keep Animation As A Subsystem
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Animation, tweening, and particles evolve over frame time rather than over repository history alone. They depend on scene state and playback time, but they are not part of the domain model or the event translation layer.
+
+**Problem:**
+
+If animation behavior is mixed into translators or scene data structures directly, visual motion policy becomes hard to tune and easy to entangle with event semantics. The renderer needs one place that owns time based visual evolution independently from event interpretation.
+
+**Decision:**
+
+Animation is kept as a dedicated subsystem inside rendering. Scene updates hand it the state and timing context it needs, while translation and scene structure code stay focused on semantic meaning and stable entity state.
+
+**Rejected:**
+
+- Embedding tween and particle behavior directly in translators.
+- Treating animation as backend only eye candy outside the rendering core.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Mixing animation timing policy with unrelated frame assembly or camera code.
+
+**Consequences:**
+
+Animation behavior becomes easier to tune, replace, and test independently from event translation. The tradeoff is that another subsystem has to stay synchronized with frame timing, scene lifecycle, and playback state.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](055-order-event-translators-by-explicit-priority.md) | [Next](057-maintain-a-scene-graph-for-visualization-state.md)

--- a/Docs/Adr/rendering/057-maintain-a-scene-graph-for-visualization-state.md
+++ b/Docs/Adr/rendering/057-maintain-a-scene-graph-for-visualization-state.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](056-keep-animation-as-a-subsystem.md) | [Next](058-render-from-immutable-scene-snapshots.md)
+
+## [057] Maintain A Scene Graph For Visualization State
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Repository visualization contains nodes, edges, labels, hoverable entities, and evolving layout state that persist across many frames. That state is richer than one immediate mode draw list and needs a structured in memory model between event translation and backend submission.
+
+**Problem:**
+
+If visual state is rebuilt from scratch for every event or hidden inside the player, the renderer loses continuity for layout, interaction, and multi frame effects. It also becomes hard to reason about identity and lifecycle for visual entities that outlive a single translation pass.
+
+**Decision:**
+
+Rendering maintains visualization state in a scene graph. Scene nodes, relationships, and subsystem owned state live in that graph until snapshot assembly extracts a renderable view.
+
+**Rejected:**
+
+- Rebuilding the scene from scratch for every event.
+- Storing visual state inside the player.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Collapsing scene identity and render submission into one immediate mode structure.
+
+**Consequences:**
+
+The renderer can evolve scene state incrementally and support interaction, layout, and effects across frames. The tradeoff is lifecycle complexity: node identity, deletion, and synchronization now have to be managed explicitly inside the rendering layer.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](056-keep-animation-as-a-subsystem.md) | [Next](058-render-from-immutable-scene-snapshots.md)

--- a/Docs/Adr/rendering/058-render-from-immutable-scene-snapshots.md
+++ b/Docs/Adr/rendering/058-render-from-immutable-scene-snapshots.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](057-maintain-a-scene-graph-for-visualization-state.md) | [Next](059-support-manual-camera-control.md)
+
+## [058] Render From Immutable Scene Snapshots
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Scene update and scene rendering do not happen for the same reasons and should not compete over mutable state. The backend needs a stable frame view while layout, animation, and hover systems continue to manage the live scene model.
+
+**Problem:**
+
+If backend rendering reads directly from the mutable scene graph, update order and timing become part of rendering correctness. That creates risks around partially updated state, frame to frame inconsistency, and accidental coupling between backend rendering and scene mutation rules.
+
+**Decision:**
+
+Backend rendering operates on immutable scene snapshots derived from the live scene graph. Snapshot assembly produces a stable render time view that the graphics layer can consume without mutating or observing the scene graph in flight.
+
+**Rejected:**
+
+- Reading the mutable scene graph directly.
+- Blocking scene updates during rendering.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Treating snapshot assembly as an optional optimization instead of a rendering boundary.
+
+**Consequences:**
+
+Frame submission sees a consistent scene image and backend code stays insulated from live mutation behavior. The tradeoff is extra snapshot assembly work and another contract that must stay aligned with scene state.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](057-maintain-a-scene-graph-for-visualization-state.md) | [Next](059-support-manual-camera-control.md)

--- a/Docs/Adr/rendering/059-support-manual-camera-control.md
+++ b/Docs/Adr/rendering/059-support-manual-camera-control.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](058-render-from-immutable-scene-snapshots.md) | [Next](060-use-deterministic-color-palettes.md)
+
+## [059] Support Manual Camera Control
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Automatic camera behavior is useful for passive playback, but repository scenes also need inspection, debugging, and selective exploration. The rendering layer therefore needs a camera model that can switch between guided and operator driven movement.
+
+**Problem:**
+
+Automatic tracking alone is not enough to inspect dense or surprising scene states. If camera control lives outside the rendering model, input handling, focus behavior, and scene queries drift apart and become hard to coordinate.
+
+**Decision:**
+
+The renderer exposes manual camera control alongside tracking modes. Camera policy remains part of the rendering layer so that input, scene navigation, and frame assembly share one coherent view of camera state.
+
+**Rejected:**
+
+- Only an automatic camera.
+- Managing the camera outside the input/rendering model.
+- Driving manual navigation directly from backend window code with no rendering layer policy.
+- Treating camera mode as a purely UI concern outside scene behavior.
+
+**Consequences:**
+
+The operator can inspect scenes interactively without abandoning rendering layer invariants. The tradeoff is that camera state and input behavior become more coupled and need explicit coordination with hover, layout, and playback state.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](058-render-from-immutable-scene-snapshots.md) | [Next](060-use-deterministic-color-palettes.md)

--- a/Docs/Adr/rendering/060-use-deterministic-color-palettes.md
+++ b/Docs/Adr/rendering/060-use-deterministic-color-palettes.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](059-support-manual-camera-control.md) | [Next](061-use-render-state-assembly-as-a-boundary.md)
+
+## [060] Use Deterministic Color Palettes
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Color is part of how the visualization communicates actor identity, file identity, and scene continuity. If color assignment shifts unpredictably between runs, the renderer loses one of its main tools for building stable visual recognition.
+
+**Problem:**
+
+Colors for actors, files, and edges should remain repeatable across runs. Random or frame local color assignment makes screenshots, comparisons, and operator recognition less useful and turns color into decoration rather than a consistent signal.
+
+**Decision:**
+
+Color palettes are deterministic and derived from domain data. Rendering uses stable mapping rules so that the same entities resolve to the same palette behavior unless the underlying domain identity changes.
+
+**Rejected:**
+
+- Randomizing colors on each run.
+- Assigning colors from transient scene order or render time allocation order.
+- Treating color as a purely theme level concern with no domain relationship.
+- Storing final colors as mutable backend only state with no deterministic mapping rule.
+
+**Consequences:**
+
+Visualization becomes more stable for repeated inspection, screenshots, and debugging. The tradeoff is that palette design must scale to large repositories without collapsing into visually indistinguishable assignments.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](059-support-manual-camera-control.md) | [Next](061-use-render-state-assembly-as-a-boundary.md)

--- a/Docs/Adr/rendering/061-use-render-state-assembly-as-a-boundary.md
+++ b/Docs/Adr/rendering/061-use-render-state-assembly-as-a-boundary.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](060-use-deterministic-color-palettes.md) | [Next](066-buffer-and-aggregate-playback-events-before-scene-dispatch.md)
+
+## [061] Use Render State Assembly As A Boundary
+
+*2026-02* | Status: accepted
+
+**Context:**
+
+The graphics backend expects one coherent input object per frame, but the rendering layer builds that input from multiple sources: camera state, scene snapshots, HUD data, diagnostics, and selection state. Those sources should not be coupled directly to backend submission.
+
+**Problem:**
+
+If each output assembles frame state on its own, backend adapters end up re encoding scene contracts and HUD composition rules locally. That makes outputs harder to keep consistent and spreads frame shape decisions outside the rendering core.
+
+**Decision:**
+
+`RenderStateAssembler` builds an explicit render state as a dedicated boundary object. Rendering systems contribute source state, and backend outputs consume the assembled result instead of composing that frame contract themselves.
+
+**Rejected:**
+
+- Letting every output assemble state on its own.
+- Treating the HUD and scene as unrelated data sources.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Mixing frame assembly responsibilities into backend adapters or scene systems.
+
+**Consequences:**
+
+Outputs receive a consistent view of one frame contract, and backend code stays simpler. The tradeoff is that the assembler becomes an important integration point whose shape has to evolve carefully with both scene and HUD behavior.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](060-use-deterministic-color-palettes.md) | [Next](066-buffer-and-aggregate-playback-events-before-scene-dispatch.md)

--- a/Docs/Adr/rendering/066-buffer-and-aggregate-playback-events-before-scene-dispatch.md
+++ b/Docs/Adr/rendering/066-buffer-and-aggregate-playback-events-before-scene-dispatch.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](061-use-render-state-assembly-as-a-boundary.md) | [Next](067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md)
+
+## [066] Buffer And Aggregate Playback Events Before Scene Dispatch
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`RenderingPipeline` does not dispatch raw `TraceEvent` objects directly into the scene. Events coming from the player go into `RenderEventBuffer`, pass through `TraceEventAggregationStage`, and only after flush become semantic input for translators and scene dispatchers.
+
+**Problem:**
+
+Rendering needs to work on semantic groups and configurable event types, not on every raw event as soon as it arrives. Without a buffer and aggregation stage, scene logic would have to understand low level events, bundling semantics, and enabling or disabling render event categories all at once.
+
+**Decision:**
+
+Playback events are first buffered and aggregated inside the rendering layer, and the scene only sees the resulting semantic stream. Changing active `RenderEventKinds` rebuilds aggregation state instead of scattering filtering conditions across translators and scene handlers.
+
+**Rejected:**
+
+- Dispatching raw `TraceEvent` directly to `SceneCommandDispatcher`.
+- Aggregating only on the side of the scene graph or renderers.
+- Mixing `RenderEventKinds` filtering with translator logic.
+- One shot event processing with no ability to flush or reset aggregation state.
+
+**Consequences:**
+
+Rendering receives higher level semantic inputs and can control which event categories participate in scene construction at all. The cost is extra pipeline state that must be reset correctly when render event modes change or playback is cleared.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](061-use-render-state-assembly-as-a-boundary.md) | [Next](067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md)

--- a/Docs/Adr/rendering/067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md
+++ b/Docs/Adr/rendering/067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](066-buffer-and-aggregate-playback-events-before-scene-dispatch.md) | [Next](070-represent-scene-relations-explicitly.md)
+
+## [067] Route Renderable Semantic Events Through An Explicit Dispatch Table
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+After aggregation flush, `RenderingPipeline` does not keep separate branches for every event type scattered across the code. `RenderEventDispatchTable` maintains an explicit `RenderEventKinds -> DispatchFn` map that connects renderable categories with the appropriate semantic writer.
+
+**Problem:**
+
+As the number of semantic event types grows, manual branching in the pipeline quickly becomes a source of accidental mismatches between `RenderEventKinds` flags, writers, and dispatch calls. Rendering needs one place where the full routing of supported event classes is visible.
+
+**Decision:**
+
+Routing semantic events into the scene pipeline is maintained in an explicit dispatch table. Rendering treats renderable types as a declarative map rather than a set of hidden conditions in many classes.
+
+**Rejected:**
+
+- Scattering `switch` or `if` branches throughout `RenderingPipeline`.
+- Resolving handlers by reflection on every flush.
+- Coupling `RenderEventKinds` configuration directly to specific translators.
+- Hiding routing inside aggregators instead of maintaining an explicit dispatch boundary.
+
+**Consequences:**
+
+Adding a new render event category requires one explicit entry and keeps routing in a single place. The drawback is that the dispatch table becomes a central compatibility contract between aggregation, translation, and the rest of the scene pipeline.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](066-buffer-and-aggregate-playback-events-before-scene-dispatch.md) | [Next](070-represent-scene-relations-explicitly.md)

--- a/Docs/Adr/rendering/070-represent-scene-relations-explicitly.md
+++ b/Docs/Adr/rendering/070-represent-scene-relations-explicitly.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md) | [Next](071-use-flyweight-backed-scene-nodes.md)
+
+## [070] Represent Scene Relations Explicitly
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Repository visualization is not just a set of isolated nodes. Branches, authors, files, and derived entities often need visible or queryable relationships that remain meaningful across layout, hover, and rendering passes.
+
+**Problem:**
+
+If scene relations are left implicit or reconstructed only inside GPU renderers, layout and interaction code have no stable way to reason about connectivity. That spreads relation semantics across multiple systems and makes it harder to preserve consistent behavior.
+
+**Decision:**
+
+Scene relations are represented explicitly in the rendering model. Relation structures live alongside scene entities so that layout, hover, bundling, and frame assembly can consume the same connectivity semantics.
+
+**Rejected:**
+
+- Computing relations only in the GPU renderer.
+- Encoding every relation as an incidental property on unrelated node types.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Reconstructing connectivity heuristically in each scene subsystem.
+
+**Consequences:**
+
+Layout and interaction systems can share one model of connectivity instead of inferring it repeatedly. The tradeoff is that relation maintenance becomes part of scene lifecycle management and must stay aligned with translation output.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md) | [Next](071-use-flyweight-backed-scene-nodes.md)

--- a/Docs/Adr/rendering/071-use-flyweight-backed-scene-nodes.md
+++ b/Docs/Adr/rendering/071-use-flyweight-backed-scene-nodes.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](070-represent-scene-relations-explicitly.md) | [Next](072-use-hive-layout-for-repository-visualization.md)
+
+## [071] Use Flyweight Backed Scene Nodes
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+The rendering layer may hold large numbers of scene entities that share stable descriptive data while differing only in position, state, or transient render metadata. Duplicating the full payload in each node would waste memory and complicate updates.
+
+**Problem:**
+
+A large scene graph amplifies allocation pressure if every node owns a full copy of its descriptive state. That makes high entity count views more expensive and turns shared metadata updates into repeated node local mutations.
+
+**Decision:**
+
+Scene nodes use flyweight backed state where descriptive data can be shared safely. Node instances keep the per entity dynamic state they need, while reusable identity or metadata stays in shared backing structures.
+
+**Rejected:**
+
+- Keeping a full data copy in every node.
+- Moving all node data into global bags with no typed node ownership.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Solving memory pressure only through backend level optimization after scene allocation already happened.
+
+**Consequences:**
+
+Scene memory use scales better in dense views and shared metadata changes become easier to centralize. The tradeoff is more indirection in node access and a stricter need to preserve flyweight identity and lifetime rules.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](070-represent-scene-relations-explicitly.md) | [Next](072-use-hive-layout-for-repository-visualization.md)

--- a/Docs/Adr/rendering/072-use-hive-layout-for-repository-visualization.md
+++ b/Docs/Adr/rendering/072-use-hive-layout-for-repository-visualization.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](071-use-flyweight-backed-scene-nodes.md) | [Next](073-advance-scene-systems-through-a-dedicated-frame-updater.md)
+
+## [072] Use Hive Layout For Repository Visualization
+
+*2026-05* | Status: accepted
+
+**Context:**
+
+Generic force based placement does not necessarily reveal repository structure well enough for this domain. The visualization needs a layout model that can express repository centric grouping and navigation patterns rather than only generic graph aesthetics.
+
+**Problem:**
+
+A generic layout can preserve connectivity while still producing scenes that are hard to read as repository history. The renderer needs a layout model that reflects the kinds of clusters and navigation affordances expected from this domain.
+
+**Decision:**
+
+Repository visualization uses a Hive layout as a first class rendering policy. Layout rules are tailored to repository structure rather than inherited from a generic graph layout algorithm with minimal domain adaptation.
+
+**Rejected:**
+
+- Manual positioning of nodes.
+- Treating generic force layout as the default for every repository view.
+- Building visual behavior directly from the timeline model without a separate scene representation.
+- Pushing domain specific layout rules down into backend renderers instead of keeping them in rendering policy.
+
+**Consequences:**
+
+The scene reflects repository specific structure more clearly and layout behavior can be tuned as a rendering concern. The tradeoff is that layout policy becomes more domain specific and therefore needs explicit tests and performance scrutiny of its own.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](071-use-flyweight-backed-scene-nodes.md) | [Next](073-advance-scene-systems-through-a-dedicated-frame-updater.md)

--- a/Docs/Adr/rendering/073-advance-scene-systems-through-a-dedicated-frame-updater.md
+++ b/Docs/Adr/rendering/073-advance-scene-systems-through-a-dedicated-frame-updater.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](072-use-hive-layout-for-repository-visualization.md) | [Next](074-assemble-and-submit-render-frames-through-a-thin-boundary.md)
+
+## [073] Advance Scene Systems Through A Dedicated Frame Updater
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`SceneFrameUpdater` owns frame step logic: computing `dt` from player wall time, stepping layout, ticking animation, updating edges, decaying actors, and moving the camera. `RenderingPipeline` delegates updates to it instead of owning every update sequence itself.
+
+**Problem:**
+
+Scene simulation has several separate subsystems, but all depend on the same frame rhythm and player state. Without a dedicated update component, playback semantics, scene simulation, and render state submission quickly mix in one class, making `dt` tuning, time resets, and update order consistency harder.
+
+**Decision:**
+
+All frame level scene updates are executed through a dedicated frame updater. It is responsible for clamping `dt`, adjusting layout step count to playback speed, and maintaining a stable subsystem update order.
+
+**Rejected:**
+
+- Ticking layout, animation, and camera directly in `RenderingPipeline`.
+- Using renderer or window time as the source of `dt` instead of wall time reported by the player.
+- Advancing layout only once per frame regardless of playback speed.
+- Leaving time reset and `paused/idle` logic scattered across multiple classes.
+
+**Consequences:**
+
+Scene update order becomes stable and can be tuned without touching event flushing or frame assembly logic. The cost is another coordination layer whose correctness affects layout, animation, and camera behavior during fast playback and resets.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](072-use-hive-layout-for-repository-visualization.md) | [Next](074-assemble-and-submit-render-frames-through-a-thin-boundary.md)

--- a/Docs/Adr/rendering/074-assemble-and-submit-render-frames-through-a-thin-boundary.md
+++ b/Docs/Adr/rendering/074-assemble-and-submit-render-frames-through-a-thin-boundary.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](073-advance-scene-systems-through-a-dedicated-frame-updater.md) | [Next](075-resolve-hover-state-through-a-separate-scene-query-service.md)
+
+## [074] Assemble And Submit Render Frames Through A Thin Boundary
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`RenderFrameAssembler` is a thin boundary between rendering logic and the output backend. It gathers the dependencies required to build `RenderState` through `IRenderStateAssembler` and then passes the finished snapshot to `IRenderOutput`.
+
+**Problem:**
+
+Render state assembly and frame delivery to the backend are two different contracts. When the pipeline both builds state and drives the output directly, the boundary between logical frame representation and graphics backend execution becomes harder to preserve.
+
+**Decision:**
+
+Frame assembly and submission are kept behind a thin frame assembler that connects `IRenderStateAssembler` with `IRenderOutput`. `RenderingPipeline` does not talk to the output at the level of state details; it only passes the parameters needed to build one immutable frame.
+
+**Rejected:**
+
+- Direct `assembler.Assemble(...); output.Submit(...)` calls scattered through the pipeline.
+- Exposing a mutable scene graph directly to the output backend.
+- Combining HUD assembly, snapshots, and submission with the frame updater.
+- Moving responsibility for `RenderState` construction into the `graphics/` backend.
+
+**Consequences:**
+
+The `rendering -> output` boundary remains clear, and `RenderState` retains the role of the single frame contract. The cost is a small extra delegation step and the need to keep the parameters passed to the assembler aligned with what the backend expects.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](073-advance-scene-systems-through-a-dedicated-frame-updater.md) | [Next](075-resolve-hover-state-through-a-separate-scene-query-service.md)

--- a/Docs/Adr/rendering/075-resolve-hover-state-through-a-separate-scene-query-service.md
+++ b/Docs/Adr/rendering/075-resolve-hover-state-through-a-separate-scene-query-service.md
@@ -1,0 +1,30 @@
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](074-assemble-and-submit-render-frames-through-a-thin-boundary.md)
+
+## [075] Resolve Hover State Through A Separate Scene Query Service
+
+*2026-06* | Status: accepted
+
+**Context:**
+
+`HoverPickingService` keeps mouse position state, converts screen coordinates into world space, finds the nearest `SceneNode`, and optionally resolves an active hive pod. The rendering pipeline uses it as a separate data source for the HUD instead of mixing hit testing with scene updates or the output backend.
+
+**Problem:**
+
+Hover and picking are logically tied to the scene, camera, and layout, but they are not part of scene simulation itself or the graphics backend. When hit testing is hidden in the renderer, window, or node snapshots, responsibility for interaction, scene representation, and HUD presentation gets mixed quickly.
+
+**Decision:**
+
+Hover state resolution is maintained as a separate query service over scene and layout. The pipeline passes cursor changes into it, and the result feeds HUD assembly and renderer state without mutating the scene graph.
+
+**Rejected:**
+
+- Performing hit testing directly in the `graphics/` backend.
+- Keeping hover state inside `SceneNode` or `CameraController`.
+- Computing hover only during HUD rendering instead of before frame assembly.
+- Separate, inconsistent picking implementations for nodes and hive pods.
+
+**Consequences:**
+
+Interaction remains part of the rendering layer, but it does not contaminate the scene model or the output backend. The cost is an extra component that depends on the scene, camera, and layout and must remain aligned with zoom, rotation, and layout mode semantics.
+
+[ADR Home](../README.md) | [Category Index](./README.md) | [Previous](074-assemble-and-submit-render-frames-through-a-thin-boundary.md)

--- a/Docs/Adr/rendering/README.md
+++ b/Docs/Adr/rendering/README.md
@@ -1,0 +1,40 @@
+[ADR Home](../README.md)
+
+# rendering
+
+This category covers the logical rendering pipeline from events to scene state and layout.
+
+## Scope
+
+Look here for render commands, scene graph, snapshots, render state, translation, frame assembly, and layout as a visual model independent of the GPU runtime.
+
+## Responsibility Boundaries
+
+Rendering should not define domain meaning and should not absorb OpenGL runtime concerns. It is the middle layer between domain and graphics.
+
+## How To Start Reading
+
+Start here when changing scene behavior, translators, layout, or render state assembly.
+
+## ADR List
+
+| ADR | Title |
+| --- | --- |
+| [050-separate-rendering-core-from-graphics-runtime.md](./050-separate-rendering-core-from-graphics-runtime.md) | Separate Rendering Core From Graphics Runtime |
+| [051-translate-trace-events-into-render-commands.md](./051-translate-trace-events-into-render-commands.md) | Translate Trace Events Into Render Commands |
+| [052-use-render-commands-as-visual-intent.md](./052-use-render-commands-as-visual-intent.md) | Use Render Commands As Visual Intent |
+| [055-order-event-translators-by-explicit-priority.md](./055-order-event-translators-by-explicit-priority.md) | Order Event Translators By Explicit Priority |
+| [056-keep-animation-as-a-subsystem.md](./056-keep-animation-as-a-subsystem.md) | Keep Animation As A Subsystem |
+| [057-maintain-a-scene-graph-for-visualization-state.md](./057-maintain-a-scene-graph-for-visualization-state.md) | Maintain A Scene Graph For Visualization State |
+| [058-render-from-immutable-scene-snapshots.md](./058-render-from-immutable-scene-snapshots.md) | Render From Immutable Scene Snapshots |
+| [059-support-manual-camera-control.md](./059-support-manual-camera-control.md) | Support Manual Camera Control |
+| [060-use-deterministic-color-palettes.md](./060-use-deterministic-color-palettes.md) | Use Deterministic Color Palettes |
+| [061-use-render-state-assembly-as-a-boundary.md](./061-use-render-state-assembly-as-a-boundary.md) | Use Render State Assembly As A Boundary |
+| [066-buffer-and-aggregate-playback-events-before-scene-dispatch.md](./066-buffer-and-aggregate-playback-events-before-scene-dispatch.md) | Buffer And Aggregate Playback Events Before Scene Dispatch |
+| [067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md](./067-route-renderable-semantic-events-through-an-explicit-dispatch-table.md) | Route Renderable Semantic Events Through An Explicit Dispatch Table |
+| [070-represent-scene-relations-explicitly.md](./070-represent-scene-relations-explicitly.md) | Represent Scene Relations Explicitly |
+| [071-use-flyweight-backed-scene-nodes.md](./071-use-flyweight-backed-scene-nodes.md) | Use Flyweight Backed Scene Nodes |
+| [072-use-hive-layout-for-repository-visualization.md](./072-use-hive-layout-for-repository-visualization.md) | Use Hive Layout For Repository Visualization |
+| [073-advance-scene-systems-through-a-dedicated-frame-updater.md](./073-advance-scene-systems-through-a-dedicated-frame-updater.md) | Advance Scene Systems Through A Dedicated Frame Updater |
+| [074-assemble-and-submit-render-frames-through-a-thin-boundary.md](./074-assemble-and-submit-render-frames-through-a-thin-boundary.md) | Assemble And Submit Render Frames Through A Thin Boundary |
+| [075-resolve-hover-state-through-a-separate-scene-query-service.md](./075-resolve-hover-state-through-a-separate-scene-query-service.md) | Resolve Hover State Through A Separate Scene Query Service |


### PR DESCRIPTION
## Summary

This PR does four concrete things in the codebase:

- builds dedicated ADR corpus under `Docs/Adr` with architecture based categories
- numbers ADRs against Git history using the earliest relevant source file commits
- expands ADR content into engineering records with context, decisions, rejected alternatives, and consequences
- standardizes the full corpus in English and adds navigation plus category indexes

## ADR Structure

- adds main ADR index in `Docs/Adr/README.md`
- adds category indexes for foundation, core, persistence, composition, cli, auth-workspace, providers, export, player, rendering, graphics, aggregation, and diagnostics
- adds global ADR numbering with Previous/Next navigation in each record
- organizes ADRs with an architecture based folder structure

## History and Mapping

- orders ADRs by Git history chronology rather than manual grouping
- maps decisions to relevant source files and sorts them by the earliest corresponding commit
- keeps category indexes and local navigation aligned with the ADR numbering
- aligns the ADR corpus with both project history and current code boundaries

## Content and Coverage

- expands player, rendering, graphics, buffer/runtime, provider, exporter, and shader decisions from actual code paths
- broadens rejected alternatives to capture realistic engineering tradeoffs
- writes ADRs to describe architectural decisions rather than replaying commit messages
- expands category README files into technical entry points instead of placeholder indexes

## Result

- the repository now has structured ADR corpus mapped to real code ownership boundaries
- architectural decisions are easier to navigate by subsystem and chronology
- the documentation is consistent enough to use as a technical reference during implementation, review, and future design changes