### PR TITLE
fix: Command Injection Fix for ChangeTrace

### DIFF
--- a/scripts/releases/prepare_prerelease.py
+++ b/scripts/releases/prepare_prerelease.py
@@ -30,6 +30,9 @@ def main() -> int:
 
     github_output = require_env("GITHUB_OUTPUT")[0]
 
+    # Sanitize release_name to prevent GitHub Actions environment variable injection
+    release_name = release_name.replace("\n", "").replace("\r", "")
+
     with open(github_output, "a", encoding="utf-8") as handle:
         handle.write(f"tag_name={tag_name}\n")
         handle.write(f"release_version={tag_name.removeprefix('v')}\n")


### PR DESCRIPTION
Hey there! 👋

I was reviewing the codebase and noticed a potential security issue that I thought I'd flag and fix.

## What I found

- **[HIGH] rce** in `scripts/releases/prepare_prerelease.py`: GitHub Actions environment variable injection via GITHUB_OUTPUT. The `release_name` variable is derived from the `INPUT_

## What I changed

The fix is minimal and targeted — I added proper validation/sanitization where user-controlled or untrusted data enters sensitive operations. No changes to existing functionality or public APIs.

## Testing

Ran the existing test suite locally, everything passes. The change is backward-compatible.

Happy to discuss if you have questions!

Relates to: https://github.com/rian-be/ChangeTrace/issues/50

---
💛 If this fix helps, donations are appreciated (ETH/ERC-20): `0x1478f1BDEACc7b434b4405350A15993cDcddc79F` ([Etherscan](https://etherscan.io/address/0x1478f1BDEACc7b434b4405350A15993cDcddc79F))